### PR TITLE
Add CAM6 suite definition file

### DIFF
--- a/suite_cam6.xml
+++ b/suite_cam6.xml
@@ -47,7 +47,6 @@
       <scheme>check_energy_chng</scheme>        <!-- Global integral checker required for certain diagnostic outputs -->
       <scheme>check_tracers_chng</scheme>       <!-- Global tracer mass checker that kills model if error is large enough. -->
       <scheme>sslt_rebin_adv</scheme>           <!-- Only matters if certain sea salt species are present in chemistry package-->
-      <scheme>carma_timestep_tend</scheme>      <!-- Only matters if CARMA is active -->
       <subcycle loop="cloud_macmic_num_steps">  <!-- Cloud macrophysics-microphysics loop -->
         <!-- CLUBB turbulence, convection, and macrophysics -->
         <!-- **************************** -->
@@ -180,7 +179,6 @@
       <scheme>ma_convproc_intr</scheme>               <!-- Convective in-cloud aerosol removal parameterization, only used if convproc_do_aer is True -->
       <scheme>set_srf_wetdep</scheme>                 <!-- Add aerosol deposition rates to host model surface fluxes -->
       <!-- **************************** -->
-      <scheme>carma_wetdep_tend</scheme>              <!-- Apply CARMA's wet deposition routine.  Only matters if CARMA is active -->
       <scheme>convtran</scheme>                       <!-- Actual ZM convective transport scheme, for constituents in cnst_is_convtran2 -->
       <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
       <scheme>diag_phys_writeout</scheme>             <!-- Calculate generic atmospheric physics diagnostics and output them to history file -->
@@ -247,7 +245,6 @@
       <scheme>srf_emis_diag_output</scheme>           <!-- Add surface chemistry emissions to host model's surface inputs and history files -->
       <scheme>fire_emissions_srf</scheme>             <!-- Calculate fire emissions, and add to host model's surface inputs -->
       <!-- **************************** -->
-      <scheme>carma_emission_tend</scheme>            <!-- Calculate CARMA emissions.  Only matters if CARMA is active -->
       <scheme>check_tracers_init</scheme>             <!-- Initalize tracer/constituent mass checker -->
       <!-- Negative moisture/tracer check -->
       <!-- **************************** -->
@@ -277,7 +274,6 @@
       <scheme>ubc_get_vals</scheme>                   <!-- Calcuate upper-level boundary conditions (depends on chemistry and model-top choice) -->
       <scheme>set_top_tint_val</scheme>               <!-- Calculate air temperature at top interface level -->
       <scheme>pres_1D_convert</scheme>                <!-- Convert pressure and dry pressure into 1-D variables (managed by framework?) -->
-      <scheme>rairi_calc</scheme>                     <!-- Interpolate gas constant (rair) at layer interface levels.  Only matters if using WACCM-X -->
       <scheme>rhoi_calc</scheme>                      <!-- Interpolate air density and dry air density to layer interface levels -->
       <scheme>compute_tms</scheme>                    <!-- Calculate Turbulent Mountain Stress (TMS) tendency -->
       <scheme>tms_diag_output</scheme>                <!-- Calculate TMS diangostic variables, and output them to history file -->
@@ -302,7 +298,6 @@
       <scheme>pbl_output</scheme>                     <!-- Write PBL diagnostic variables to history files -->
       <scheme>pres_1D_finalize</scheme>               <!-- Deallocate 1-D pressure variables -->
       <!-- **************************** -->
-      <scheme>waccmx_phys_mspd_tend</scheme>          <!-- Only if WACCM-X "ionosphere" or "neutral" is being used -->
       <scheme>rayleigh_friction_tend</scheme>         <!-- Calculate Rayleigh friction tendency -->
       <scheme>check_energy_chng</scheme>              <!-- Global integral checker required for certain diagnostic outputs -->
       <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
@@ -328,7 +323,6 @@
       </subcycle>
       <scheme>set_srf_drydep</scheme>                 <!-- Add dry deposition surface fluxes to host model, if aerodep_flx_prescribed is False -->
       <!-- **************************** -->
-      <scheme>carma_timestep_tend</scheme>            <!-- Calculate CARMA microphysics.  Only matters if CARMA is active -->
       <scheme>charge_balance</scheme>                 <!-- Enforce charge nuetrality, if chemistry simulates electrons -->
       <!-- Gravit wave tendencies -->
       <!-- **************************** -->
@@ -362,14 +356,10 @@
       <scheme>pres_1D_finalize</scheme>                <!-- Deallocate 1-D pressure variables -->
       <!-- **************************** -->
       <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
-      <scheme>qbo_relax</scheme>                       <!-- Relax zonal winds towards QBO sequence.  Only matters if host model is WACCM or WACCM-X -->
       <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
       <scheme>lunar_tides_tend</scheme>                <!-- Calculate horizontal wind tendencies due to M2 lunar tide, but only if apply_lunar_tides is True -->
       <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
-      <scheme>iondrag_calc</scheme>                    <!-- Calculate ion drag and joule heating tendencies.  Only matters if host model is WACCM or WACCM-X -->
-      <scheme>waccmx_phys_ion_elec_temp_tend</scheme>  <!-- Calculate ionosphere tendencies.  Only matters if host model is WACCM-X in 'ionosphere' mode -->
       <scheme>calc_te_and_aam_budgets</scheme>         <!-- Managed by host model? -->
-      <scheme>charge_balance</scheme>                  <!-- Enforce charge nuetrality, if chemistry simulates electrons and host model is WACCM-X in 'ionosphere' mode -->
       <scheme>nudging_timestep_tend</scheme>           <!-- Apply nudging to horizontal winds, heat, and water vapor, and output diagnostics, but only if nudging is turned on. -->
       <scheme>set_dry_to_wet</scheme>                  <!-- Only matters if dycore is FV (LR) or SE -->
       <!-- Dry air mass adjuster -->                   <!-- Only matters if dycore is FV (LR), otherwise this calculation is purely diagnostic -->

--- a/suite_cam6.xml
+++ b/suite_cam6.xml
@@ -3,7 +3,7 @@
 <suite name="cam6" version="1.0">
   <group name="physics_bc">
     <!--cam6:  deep=ZM, shallow=CLUBB, macrop=CLUBB, microp=MG2, radiation=RRTMG, chem=trop_mam4 -->
-    <timesplit>
+    <time_split>
       <scheme>physics_state_check</scheme> <!-- Only if state_debug_checks is True. This scheme only looks for infs/nans, and kills the model if found. -->
       <scheme>clybry_fam_adj</scheme>      <!-- Only matters if chemistry package with Cly and Bry is used -->
       <!-- Negative moisture/tracer check -->
@@ -89,7 +89,7 @@
         <scheme>physics_state_dealloc</scheme>        <!-- This never actually happens in the current code (at least from what I could tell).  Bug? -->
         <!-- **************************** -->
         <scheme>check_energy_chng</scheme>            <!-- Global integral checker required for certain diagnostic outputs -->
-        <subcol gen=subcol_generator_name avg=subcol_averager_name>
+        <subcol gen="subcol_generator_name" avg="subcol_averager_name">
           <process_split>
             <!-- MG aerosol microphysics -->
             <!-- **************************** -->
@@ -204,14 +204,14 @@
       <scheme>calc_snow_optics_lw</scheme>            <!-- Calculate snow longwave optics -->
       <scheme>calc_snow_optics_lw</scheme>            <!-- Calculate graupel longwave optics -->
       <scheme>get_variability</scheme>                <!-- Calculate solar spectral irradiance scaling factors -->
-      <subcycle loop="N_DIAG">                        <!-- Loop over radiatively active constituents -->
+      <subcycle loop="n_diag">                        <!-- Loop over radiatively active constituents -->
         <scheme>rrtmg_state_update</scheme>           <!-- Add shortwave constiuent concentrations to RRTMG state structure -->
         <scheme>aer_rad_props_sw</scheme>             <!-- Gather/calculate aerosol shortwave optical properties (potentially provided by registry/framework?) -->
         <scheme>rad_rrtmg_sw</scheme>                 <!-- Actual RRTMG shortwave radiation parameterization -->
         <scheme>rad_sw_diag_output</scheme>           <!-- Calculate shortwave diagnostic variables, and output them to history file -->
       </subcycle>
       <scheme>rad_cnst_out</scheme>                   <!-- Calculate radiatively active constituent diagnostic variables, and output them to history file -->
-      <subcycle loop="N_DIAG">                        <!-- Loop over radiatively active constituents (combine with shortwave loop?)-->
+      <subcycle loop="n_diag">                        <!-- Loop over radiatively active constituents (combine with shortwave loop?)-->
         <scheme>rrtmg_state_update</scheme>           <!-- Add longwave constiuent concentrations to RRTMG state structure -->
         <scheme>aer_rad_props_lw</scheme>             <!-- Gather/calculate aerosol longwave optical properties (potentially provided by registry/framework?) -->
         <scheme>rad_rrtmg_lw</scheme>                 <!-- Actual RRTMG longwave radiation parameterization -->
@@ -231,10 +231,10 @@
       <scheme>tropopause_output</scheme>              <!-- Calculate tropopause diagnostic variables, and output them to history file -->
       <scheme>cam_export</scheme>                     <!-- Add various physics state variables to host model surface fluxes -->
       <scheme>diag_export</scheme>                    <!-- Output various host model surface fluxes to history file -->
-    </timesplit>
+    </time_split>
   </group>
   <group name="physics_ac">
-    <timesplit>
+    <time_split>
       <!--cam6:  diffusion=CLUBB, chem=trop_mam4 -->
       <scheme>flux_avg_run</scheme>                   <!-- Smooth/average surface fluxes, but only if phys_do_flux_avg is True -->
       <scheme>physics_state_check</scheme>            <!-- Only if state_debug_checks is True. This scheme only looks for infs/nans, and kills the model if found -->
@@ -311,7 +311,7 @@
       <scheme>calcram</scheme>                        <!-- Calculate aerodynamic resistance and friction velocity -->
       <scheme>calcram_diag_output</scheme>            <!-- Write aerodynamic resistance and friction velocity to history file -->
       <scheme>calc_atm_density</scheme>               <!-- Calculate atmospheric density -->
-      <subcyle loop="jvlc34">                         <!-- loop over vlc array index values 3 and 4 -->
+      <subcycle loop="jvlc34">                        <!-- loop over vlc array index values 3 and 4 -->
         <scheme>modal_aero_depvel_part</scheme>       <!-- Calculate dry deposition velocity for cloud droplets -->
       </subcycle>
       <subcycle loop="ntot_amode">                    <!-- Loop over aerosol modes -->
@@ -381,6 +381,6 @@
       <scheme>dtcore_reset</scheme>                    <!-- Reset "dtcore" variable to equal temperature -->
       <scheme>diag_phys_tend_writeout</scheme>         <!-- Calculate physics diagnostic variables, and output them to history file -->
       <scheme>clybry_fam_set</scheme>                  <!-- Set ClOy and BrOy mass mixig ratios. Only matters if chemistry package with Cly and Bry is used -->
-    </timesplit>
+    </time_split>
   </group>
 </suite>

--- a/suite_cam6.xml
+++ b/suite_cam6.xml
@@ -90,15 +90,12 @@
             <!-- **************************** -->
             <!-- MG cloud microphysics -->
             <!-- **************************** -->
-            <scheme>micro_mg_get_cols2_0</scheme>     <!-- Determine packed columns used by the MG2 microphysics schemes -->
+            <scheme>micro_mg_get_cols3_0</scheme>     <!-- Determine atmospheric columns used by the MG2 microphysics schemes -->
             <scheme>calc_incloud_LWP</scheme>         <!-- Calculate in-cloud Liquid Water Path (LWP) before MG2 is run -->
             <scheme>micro_calc_tropopause</scheme>    <!-- Calculate the cold-point tropopause for use by the microphysics -->
-            <scheme>mg_variable_packer</scheme>       <!-- Pack grid-domain variables together to reduce loop sizes (necessary?) -->
             <scheme>micro_mg_tend2_0</scheme>         <!-- Actual MG2 cloud micro-physics parameterization scheme -->
-            <scheme>mg_unpack_process</scheme>        <!-- Un-pack variables, and do additional processing to calculate certain variables, sums, and averages -->
             <scheme>mg_calc_outputs</scheme>          <!-- Calculate additional MG2 output variables and diagnostics -->
             <scheme>calc_atm_density</scheme>         <!-- Calculate atmospheric density -->
-            <scheme>subcol_field_avg</scheme>         <!-- Average sub-columns together to generate grid-scale values -->
             <!-- This section of code could likely be grouped together as one scheme (at least partially)-->
             <!-- +++++++++++++++++++++++++ -->
             <scheme>size_dist_param_liq</scheme>      <!-- Calculate size distribution of cloud droplets -->
@@ -115,24 +112,27 @@
             <scheme>calc_micro_column_vars</scheme>   <!-- Calculate Liquid Water Path (LWP) and net column condensation -->
             <scheme>calc_prec_efficiency</scheme>     <!-- Calculate precipitation efficiency -->
             <scheme>micro_diag_output</scheme>        <!-- Calculate microphysics diagnostic variables, and output them to history file -->
-            <!-- **************************** -->
-            <!-- SILHS subcolumn covariance -->
-            <!-- **************************** -->
-            <scheme>subcol_unpack</scheme>                     <!-- Unpack sub-column variables -->
-            <scheme>calc_total_moisture</scheme>               <!-- Combine vapor and condensate (manageable by registry/framework)? -->
-            <scheme>calc_dry_static_density</scheme>           <!-- Calculate the dry static density -->
-            <scheme>convert_omega_to_w</scheme>                <!-- Convert pressure velocity to vertical velocity, manageable by registry/framework? -->
-            <scheme>convert_dse_to_temp</scheme>               <!-- Convert dry static energy (DSE) to air temperature, manageable by registry/framework? -->
-            <scheme>exner_silhs</scheme>                       <!-- Calculate the Exner function according to SILHS (should be the same as CLUBB, but possible issues) -->
-            <scheme>thl_calc</scheme>                          <!-- Calculate liquid water potential temperature (theta-l) -->
-            <scheme>silhs_var_vert_inv</scheme>                <!-- Change order of vertical levels for SILHS input variables, and add ghost point (should be manageable via the registry/meta file) -->
-            <scheme>silhs_get_subcol_wgts</scheme>             <!--  Collect subcolumn weights for SILHS -->
-            <scheme>lh_microphys_var_covar_driver_api</scheme> <!-- Actual SILHS sub-column parameterization -->
-            <scheme>zero_upper_level</scheme>                  <!-- Set covariances above SILHS max altitude to zero -->
-            <!-- **************************** -->
-            <scheme>subcol_SILHS_fill_holes_conserv_calc</scheme> <!-- Prevent holes (values less than qmin) using mass-conserving adjustments -->
-            <scheme>massless_droplet_destroyer</scheme>           <!-- Remove massless droplets, doesn't influences only grid-scale tendencies -->
-            <scheme>subcol_SILHS_hydromet_conc_tend_lim</scheme>  <!-- Place limits on hydrometeor drop-size -->
+            <execute test="use_SILHS" default=".false." >
+              <!-- **************************** -->
+              <!-- SILHS subcolumn covariance -->
+              <!-- **************************** -->
+              <scheme>calc_total_moisture</scheme>               <!-- Combine vapor and condensate (manageable by registry/framework)? -->
+              <scheme>calc_dry_static_density</scheme>           <!-- Calculate the dry static density -->
+              <scheme>convert_omega_to_w</scheme>                <!-- Convert pressure velocity to vertical velocity, manageable by registry/framework? -->
+              <scheme>convert_dse_to_temp</scheme>               <!-- Convert dry static energy (DSE) to air temperature, manageable by registry/framework? -->
+              <scheme>exner_silhs</scheme>                       <!-- Calculate the Exner function according to SILHS (should be the same as CLUBB, but possible issues) -->
+              <scheme>thl_calc</scheme>                          <!-- Calculate liquid water potential temperature (theta-l) -->
+              <scheme>silhs_var_vert_inv</scheme>                <!-- Change order of vertical levels for SILHS input variables, and add ghost point (should be manageable via the registry/meta file) -->
+              <scheme>silhs_get_subcol_wgts</scheme>             <!--  Collect subcolumn weights for SILHS -->
+              <scheme>lh_microphys_var_covar_driver_api</scheme> <!-- Actual SILHS sub-column parameterization -->
+              <scheme>zero_upper_level</scheme>                  <!-- Set covariances above SILHS max altitude to zero -->
+              <!-- **************************** -->
+              <scheme>subcol_SILHS_fill_holes_conserv_calc</scheme> <!-- Prevent holes (values less than qmin) using mass-conserving adjustments -->
+            </execute>
+            <scheme>massless_droplet_destroyer</scheme>             <!-- Remove massless droplets, doesn't influences only grid-scale tendencies -->
+            <execute test="use_SILHS" default=".false." >
+              <scheme>subcol_SILHS_hydromet_conc_tend_lim</scheme>  <!-- Place limits on hydrometeor drop-size -->
+            </execute>
           </process_split>
           <scheme>check_energy_chng</scheme>          <!-- Global integral checker required for certain diagnostic outputs -->
         </subcol>

--- a/suite_cam6.xml
+++ b/suite_cam6.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="cam6" version="1.0">
+  <group name="physics_bc">
+    <!--cam6:  deep=ZM, shallow=CLUBB, macrop=CLUBB, microp=MG2, radiation=RRTMG, chem=trop_mam4 -->
+    <timesplit>
+      <scheme>physics_state_check</scheme> <!-- Only if state_debug_checks is True. This scheme only looks for infs/nans, and kills the model if found. -->
+      <scheme>clybry_fam_adj</scheme>      <!-- Only matters if chemistry package with Cly and Bry is used -->
+      <!-- Negative moisture/tracer check -->
+      <!-- **************************** -->
+      <scheme>qneg3</scheme>                    <!-- This scheme modifies the state directly.  Combine with state check? -->
+      <scheme>qneg3_diag_output</scheme>        <!-- Scheme to output qneg diagnostics (i.e. the "outfld" calls) -->
+      <!-- **************************** -->
+      <scheme>physics_state_check</scheme>      <!-- Only if state_debug_checks is True. This scheme only looks for infs/nans, and kills the model if found. -->
+      <scheme>diag_state_b4_phys_write</scheme> <!-- Diagnostics -->
+      <!-- energy and momentum fixer -->
+      <!-- **************************** -->
+      <scheme>calc_te_and_aam_budgets</scheme>
+      <scheme>check_energy_fix</scheme>                  <!--Only matters if dycore is FV (called "LR" in physics) or SE-->
+      <scheme>check_energy_cam_update_pre-chng</scheme>  <!-- Placeholder for CAM ptend and diagnostic output calculations before "chng" call. -->
+      <scheme>check_energy_chng</scheme>                 <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>check_energy_cam_update_post-chng</scheme> <!-- Placeholder for CAM ptend and diagnostic output calculations after "chng" call. -->
+      <scheme>calc_te_and_aam_budgets</scheme>
+      <!-- **************************** -->
+      <scheme>diag_conv_tend_ini</scheme>      <!-- Initalizes convective-scheme diagnostic outputs -->
+      <scheme>calc_dtcore</scheme>             <!-- diagnostic calculation.  Could likely be included in energy fixer scheme. -->
+      <!-- Dry adiabatic adjustment  -->
+      <!-- **************************** -->
+      <scheme>physics_state_copy</scheme>      <!-- Technically only need T and q here, not entire state -->
+      <scheme>dadadj_calc</scheme>             <!-- Actual dry adiabatic adjustment scheme -->
+      <scheme>dadadj_cam_update</scheme>       <!-- Placeholder for CAM ptend calculations -->
+      <scheme>physics_state_dealloc</scheme>
+      <!-- **************************** -->
+      <!-- Zhang-Macfarlane deep convection scheme -->
+      <!-- **************************** -->
+      <scheme>physics_state_copy</scheme>
+      <scheme>zm_convr</scheme>                 <!-- Actual deep convection routine -->
+      <scheme>zm_convr_cam_update</scheme>      <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+      <scheme>zm_conv_evap</scheme>             <!-- Actual ZM rain evaporation scheme -->
+      <scheme>zm_conv_evap_cam_update</scheme>  <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+      <scheme>momtran</scheme>                  <!-- Actual ZM momentum transport scheme -->
+      <scheme>momtran_cam_update</scheme>       <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+      <scheme>convtran</scheme>                 <!-- Actual ZM convective transport scheme, for constituents in cnst_is_convtran1 -->
+      <scheme>convtran_cam_update</scheme>      <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+      <scheme>physics_state_dealloc</scheme>
+      <!-- **************************** -->
+      <scheme>check_energy_chng</scheme>        <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>check_tracers_chng</scheme>       <!-- Global tracer mass checker that kills model if error is large enough. -->
+      <scheme>sslt_rebin_adv</scheme>           <!-- Only matters if certain sea salt species are present in chemistry package-->
+      <scheme>carma_timestep_tend</scheme>      <!-- Only matters if CARMA is active -->
+      <subcycle loop="cloud_macmic_num_steps">  <!-- Cloud macrophysics-microphysics loop -->
+        <!-- CLUBB turbulence, convection, and macrophysics -->
+        <!-- **************************** -->
+        <!--This section will likely require additional clean-up,
+            as many of these routines are simply unit or vertical
+            grid conversions, or the re-naming and re-setting
+            of host model inputs.  Thus they can likely be
+            managed by the framework itself, and won't need
+            their own scheme calls.-->
+        <scheme>physics_state_copy</scheme>
+        <scheme>set_dry_to_wet</scheme>               <!-- Convert mixing ratios from dry air to air + water vapor -->
+        <scheme>grid_size</scheme>                    <!-- Calculate grid-cell size (not sure if this will be managed by registry/interface?) -->
+        <scheme>clubb_dtime_calc</scheme>             <!-- Calculate CLUBB time-step as function of host model time-step -->
+        <scheme>exner_clubb</scheme>                  <!-- Calculate Exner function using CLUBB definition (should be manageable via the registry/meta file) -->
+        <scheme>tropopause_findChemTrop</scheme>      <!-- Calculate tropopause height -->
+        <scheme>clubb_vertical_grid_inv</scheme>      <!-- Change order of vertical levels (should be manageable by registry/meta file) -->
+        <scheme>clubb_calc_ustar</scheme>             <!-- Only matters for single-column mode -->
+        <scheme>setup_grid_heights_api</scheme>       <!-- Re-calculate CLUBB grid heights -->
+        <scheme>setup_parameters_api</scheme>         <!-- Re-calculate grid-dependent CLUBB parameters -->
+        <scheme>zt2zm_convert</scheme>                <!-- Transition variables on thermodynamic levels to momentum levels (manageable by registry/meta file?) -->
+        <scheme>clubb_var_vert_inv</scheme>           <!-- Change order of vertical levels for CLUBB input variables (should be manageable via the registry/meta file) -->
+        <subcycle loop="clubb_nadv">                  <!-- CLUBB sub-step loop (number of iterations should be calculated in the "clubb_dtime_calc" scheme) -->
+          <scheme>stats_begin_timestep_api</scheme>   <!-- Only matters if "l_stats" is True -->
+          <scheme>advance_clubb_core_api</scheme>     <!-- Actual CLUBB parameterization scheme -->
+          <scheme>update_xp2_mc_api</scheme>          <!-- Only matters if "do_rainturb" is True -->
+          <scheme>calculate_thlp2_rad_api</scheme>    <!-- Only matters if "do_cldcool" is True -->
+          <scheme>stats_end_timestep_clubb</scheme>   <!-- Only matters if "l_stats" is True -->
+        </subcycle>
+        <scheme>zm2zt_convert</scheme>                <!-- Transition variables on momentum levels to thermodynamic levels (manageable by registry/meta file?) -->
+        <scheme>clubb_var_vert_rev</scheme>           <!-- Change order of vertical levels for CLUBB output variables back to host model ordering  (should be manageable via the registry/meta file) -->
+        <scheme>clubb_upper_diss</scheme>             <!-- CLUBB energy and total water mass fixer -->
+        <scheme>clubb_cam_update</scheme>             <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+        <scheme>liquid_macro_tend</scheme>            <!-- Only matters if "clubb_do_liqsupersat" is True-->
+        <scheme>liquid_macro_CAM_update</scheme>      <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+        <scheme>conv_cond_detrain_calc</scheme>       <!-- Calculate the host model cloud condensate and energy tendencies produced by convective detrainment -->
+        <scheme>conv_cond_detrain_cam_update</scheme> <!-- Placeholder for CAM ptend and diagnostic output calculations -->
+        <scheme>set_wet_to_dry</scheme>               <!-- Convert mixing ratios from air + water vapor to dry air -->
+        <scheme>clubb_diag_output</scheme>            <!-- Calculate numerous different CLUBB diagnostic variables, and output them to history file -->
+        <scheme>physics_state_dealloc</scheme>        <!-- This never actually happens in the current code (at least from what I could tell).  Bug? -->
+        <!-- **************************** -->
+        <scheme>check_energy_chng</scheme>            <!-- Global integral checker required for certain diagnostic outputs -->
+        <subcol gen=subcol_generator_name avg=subcol_averager_name>
+          <process_split>
+            <!-- MG aerosol microphysics -->
+            <!-- **************************** -->
+            <scheme>microp_aero_run</scheme>          <!-- Some, but not all, tendencices from here are added to the state before microp.  This is done via pbuf.-->
+            <scheme>microp_aero_diag_output</scheme>  <!-- Output diagnostics from MG aerosol microphysics. -->
+            <!-- **************************** -->
+            <!-- MG cloud microphysics -->
+            <!-- **************************** -->
+            <scheme>micro_mg_get_cols2_0</scheme>     <!-- Determine packed columns used by the MG2 microphysics schemes -->
+            <scheme>calc_incloud_LWP</scheme>         <!-- Calculate in-cloud Liquid Water Path (LWP) before MG2 is run -->
+            <scheme>physics_state_copy</scheme>
+            <scheme>micro_calc_tropopause</scheme>    <!-- Calculate the cold-point tropopause for use by the microphysics -->
+            <scheme>mg_variable_packer</scheme>       <!-- Pack grid-domain variables together to reduce loop sizes (necessary?) -->
+            <scheme>micro_mg_tend2_0</scheme>         <!-- Actual MG2 cloud micro-physics parameterization scheme -->
+            <scheme>mg_unpack_process</scheme>        <!-- Un-pack variables, and do additional processing to calculate certain variables, sums, and averages -->
+            <scheme>mg_calc_outputs</scheme>          <!-- Calculate additional MG2 output variables and diagnostics -->
+            <scheme>calc_atm_density</scheme>         <!-- Calculate atmospheric density -->
+            <scheme>subcol_field_avg</scheme>         <!-- Average sub-columns together to generate grid-scale values -->
+            <!-- This section of code could likely be grouped together as one scheme (at least partially)-->
+            <!-- +++++++++++++++++++++++++ -->
+            <scheme>size_dist_param_liq</scheme>      <!-- Calculate size distribution of cloud droplets -->
+            <scheme>micro_eff_radius_liq</scheme>     <!-- Calculate the effective radius of a given cloud droplet distribution -->
+            <scheme>calc_ncic_grid</scheme>           <!-- Calculate ncic (number of cloud droplets?) in grid cell -->
+            <scheme>size_dist_param_liq</scheme>      <!-- Calculate size distribution of cloud droplets -->
+            <scheme>micro_eff_radius_liq</scheme>     <!-- Calculate the effective radius of a given cloud droplet distribution -->
+            <scheme>micro_eff_radius_rain</scheme>    <!-- Calculate the effective radius of rain (assumed size distribution?) -->
+            <scheme>micro_eff_radius_snow</scheme>    <!-- Calculate the effective radius of snow (assumed size distribution?) -->
+            <scheme>calc_niic_grid</scheme>           <!-- Calculate niic (number of cloud ice crystals?) in grid cell -->
+            <scheme>size_dist_param_basic</scheme>    <!-- Calculate the size distribution of ice crystals -->
+            <scheme>micro_eff_radius_ice</scheme>     <!-- Calculate the effective radius of a given cloud ice distribution -->
+            <!-- +++++++++++++++++++++++++ -->
+            <scheme>calc_micro_column_vars</scheme>   <!-- Calculate Liquid Water Path (LWP) and net column condensation -->
+            <scheme>calc_prec_efficiency</scheme>     <!-- Calculate precipitation efficiency -->
+            <scheme>micro_diag_output</scheme>        <!-- Calculate microphysics diagnostic variables, and output them to history file -->
+            <scheme>physics_state_dealloc</scheme>
+            <!-- **************************** -->
+            <!-- SILHS subcolumn covariance -->
+            <!-- **************************** -->
+            <scheme>subcol_unpack</scheme>                     <!-- Unpack sub-column variables -->
+            <scheme>calc_total_moisture</scheme>               <!-- Combine vapor and condensate (manageable by registry/framework)? -->
+            <scheme>calc_dry_static_density</scheme>           <!-- Calculate the dry static density -->
+            <scheme>convert_omega_to_w</scheme>                <!-- Convert pressure velocity to vertical velocity, manageable by registry/framework? -->
+            <scheme>convert_dse_to_temp</scheme>               <!-- Convert dry static energy (DSE) to air temperature, manageable by registry/framework? -->
+            <scheme>exner_silhs</scheme>                       <!-- Calculate the Exner function according to SILHS (should be the same as CLUBB, but possible issues) -->
+            <scheme>thl_calc</scheme>                          <!-- Calculate liquid water potential temperature (theta-l) -->
+            <scheme>silhs_var_vert_inv</scheme>                <!-- Change order of vertical levels for SILHS input variables, and add ghost point (should be manageable via the registry/meta file) -->
+            <scheme>silhs_get_subcol_wgts</scheme>             <!--  Collect subcolumn weights for SILHS -->
+            <scheme>lh_microphys_var_covar_driver_api</scheme> <!-- Actual SILHS sub-column parameterization -->
+            <scheme>zero_upper_level</scheme>                  <!-- Set covariances above SILHS max altitude to zero -->
+            <!-- **************************** -->
+            <scheme>subcol_SILHS_fill_holes_conserv_calc</scheme> <!-- Prevent holes (values less than qmin) using mass-conserving adjustments -->
+            <scheme>massless_droplet_destroyer</scheme>           <!-- Remove massless droplets, doesn't influences only grid-scale tendencies -->
+            <scheme>subcol_SILHS_hydromet_conc_tend_lim</scheme>  <!-- Place limits on hydrometeor drop-size -->
+          </process_split>
+          <scheme>check_energy_chng</scheme>          <!-- Global integral checker required for certain diagnostic outputs -->
+        </subcol>
+        <scheme>diag_clip_tend_writeout</scheme>      <!-- Output water mass clipping diagnostics to history file -->
+        <scheme>check_energy_chng</scheme>            <!-- Global integral checker required for certain diagnostic outputs -->
+        <scheme>calc_prec_sum</scheme>                <!-- Sum surface precipitation amounts over each subcycle loop -->
+      </subcycle>
+      <scheme>calc_prec_avg</scheme>                  <!-- Divide surface precipitation sum by number of "macmic" subcycle iterations -->
+      <scheme>modal_aero_calcsize_diag</scheme>       <!-- Only if climatological aerosols are used instead of prognostic aerosols -->
+      <!-- Modal Aerosol water uptake -->             <!-- Only if climatological aerosols are used instead of prognostic aerosols -->
+      <!-- **************************** -->
+      <scheme>tropopause_find</scheme>                <!-- Calculate tropopause height -->
+      <scheme>calc_h2so4_equilib_mixrat</scheme>      <!-- Calculate Sulfuric acid phase equilibrium, if modal_strat_sulfate is True -->
+      <scheme>h2so4_equilib_diag</scheme>             <!-- Output sulfer aerosol diagnostics to history file -->
+      <scheme>qsat_water</scheme>                     <!-- Calculate saturation vapor pressure with respect to liquid water -->
+      <scheme>relhum_calc</scheme>                    <!-- Calculate the relative humidity -->
+      <scheme>calc_atm_density</scheme>               <!-- Calculate atmospheric density -->
+      <scheme>modal_aero_wateruptake_sub</scheme>     <!-- Actual aerosol moisture up-take parameterization -->
+      <scheme>modal_aero_wetdens_calc</scheme>        <!-- Calculate the wet density of aerosols -->
+      <scheme>modal_aero_wateruptake_diag</scheme>    <!-- Calculate aerosol water uptake diagnostic variables, and output them to history file -->
+      <!-- **************************** -->
+      <!-- Aerosol wet deposition -->
+      <!-- **************************** -->
+      <scheme>modal_aero_calcsize_sub</scheme>        <!-- Calculate  aerosol size distribution parameters -->
+      <scheme>modal_aero_wateruptake_dr</scheme>      <!-- Repeat "Modal Aerosol water uptake" schemes shown above -->
+      <scheme>wetdep_prec_calc</scheme>               <!-- Calculate precipitation amount that impacts wet deposition -->
+      <scheme>coarse_fact_calc</scheme>               <!-- Calculate "f_act_conv" for coarse mode aerosols (note here the comments don't match the variables) -->
+      <subcycle loop="ntot_amode">                    <!-- Loop over aerosol modes -->
+        <subcycle loop="lphase">                      <!-- Loop over aerosol phase types (interstitial vs cloud-borne -->
+          <scheme>aero_fact_calc</scheme>             <!-- Calculate aerosol activation fraction (f_act_conv) depending on aerosol type -->
+          <scheme>wetdepa_v2</scheme>                 <!-- Actual aerosol wet deposition parameterization -->
+          <scheme>wetdep_diag_output</scheme>         <!-- Calculate numerous different CLUBB diagnostic variables, and output them to history file -->
+        </subcycle>
+      </subcycle>
+      <scheme>ma_convproc_intr</scheme>               <!-- Convective in-cloud aerosol removal parameterization, only used if convproc_do_aer is True -->
+      <scheme>set_srf_wetdep</scheme>                 <!-- Add aerosol deposition rates to host model surface fluxes -->
+      <!-- **************************** -->
+      <scheme>carma_wetdep_tend</scheme>              <!-- Apply CARMA's wet deposition routine.  Only matters if CARMA is active -->
+      <scheme>convtran</scheme>                       <!-- Actual ZM convective transport scheme, for constituents in cnst_is_convtran2 -->
+      <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
+      <scheme>diag_phys_writeout</scheme>             <!-- Calculate generic atmospheric physics diagnostics and output them to history file -->
+      <scheme>diag_conv</scheme>                      <!-- Calculate generic precipitation and convection diagnostics and output them to history file -->
+      <scheme>cloud_diagnostics_calc</scheme>         <!-- Calculate generic cloud diagnostics and output them to history file -->
+      <!-- RRTMG radiation -->
+      <!-- **************************** -->
+      <scheme>calc_solar_zenith_ang</scheme>          <!-- Calculate the solar zenith angle for the given time step -->
+      <scheme>group_day_night</scheme>                <!-- Determine which columns are in the day-side, vs night-side -->
+      <scheme>tropopause_find</scheme>                <!-- Calculate tropopause height -->
+      <scheme>rrtmg_state_create</scheme>             <!-- Create RRTMG state object -->
+      <scheme>calc_cldfprime</scheme>                 <!-- Calculate "prime" cloud fraction -->
+      <scheme>calc_ice_optics_sw</scheme>             <!-- Calculate cloud ice shortwave optics (case structure, may need to be broken up) -->
+      <scheme>calc_liq_optics_sw</scheme>             <!-- Calculate cloud liquid shortwave optics (case structure, may need to be broken up) -->
+      <scheme>calc_snow_optics_sw</scheme>            <!-- Calculate snow shortwave optics -->
+      <scheme>calc_snow_optics_sw</scheme>            <!-- Calculate graupel shortwave optics -->
+      <scheme>rrtmg_state_tau_add</scheme>            <!-- Calculate and add various optical depths to the RRTMG state structure -->
+      <scheme>radiation_output_cld</scheme>           <!-- Output optical depth diagnostics to history file -->
+      <scheme>calc_ice_optics_lw</scheme>             <!-- Calculate cloud ice longwave optics (case structure, may need to be broken up) -->
+      <scheme>calc_liq_optics_lw</scheme>             <!-- Calculate cloud liquid longwave optics (case structure, may need to be broken up) -->
+      <scheme>calc_snow_optics_lw</scheme>            <!-- Calculate snow longwave optics -->
+      <scheme>calc_snow_optics_lw</scheme>            <!-- Calculate graupel longwave optics -->
+      <scheme>get_variability</scheme>                <!-- Calculate solar spectral irradiance scaling factors -->
+      <subcycle loop="N_DIAG">                        <!-- Loop over radiatively active constituents -->
+        <scheme>rrtmg_state_update</scheme>           <!-- Add shortwave constiuent concentrations to RRTMG state structure -->
+        <scheme>aer_rad_props_sw</scheme>             <!-- Gather/calculate aerosol shortwave optical properties (potentially provided by registry/framework?) -->
+        <scheme>rad_rrtmg_sw</scheme>                 <!-- Actual RRTMG shortwave radiation parameterization -->
+        <scheme>rad_sw_diag_output</scheme>           <!-- Calculate shortwave diagnostic variables, and output them to history file -->
+      </subcycle>
+      <scheme>rad_cnst_out</scheme>                   <!-- Calculate radiatively active constituent diagnostic variables, and output them to history file -->
+      <subcycle loop="N_DIAG">                        <!-- Loop over radiatively active constituents (combine with shortwave loop?)-->
+        <scheme>rrtmg_state_update</scheme>           <!-- Add longwave constiuent concentrations to RRTMG state structure -->
+        <scheme>aer_rad_props_lw</scheme>             <!-- Gather/calculate aerosol longwave optical properties (potentially provided by registry/framework?) -->
+        <scheme>rad_rrtmg_lw</scheme>                 <!-- Actual RRTMG longwave radiation parameterization -->
+        <scheme>rad_lw_diag_output</scheme>           <!-- Calculate longwave diagnostic variables, and output them to history file -->
+      </subcycle>
+      <scheme>rrtmg_state_destroy</scheme>            <!-- De-construct RRTMG state structure -->
+      <scheme>calc_cosp_input_vars</scheme>           <!-- Calculate input variables required for COSP.  Only matters if COSP is active -->
+      <scheme>cospsimulator_intr_run</scheme>         <!-- Actual COSP simulator paramaterization -->
+      <scheme>rad_qdp_q_calc</scheme>                 <!-- Convert Q*dp to Q (potentially managed by registry/framework?) -->
+      <scheme>rad_data_write</scheme>                 <!-- Calculate additional radiation diagnostics, and output them to history file -->
+      <scheme>radheat_tend</scheme>                   <!-- Calculate net radiative heating tendencies -->
+      <scheme>radheat_diag_output</scheme>            <!-- Calculate radiative heating diagnostic variables, and output them to history file -->
+      <scheme>rad_q_qdp_calc</scheme>                 <!-- Convert Q to Q*dp (potentially managed by registry/framework?) -->
+      <scheme>set_srf_net_sw</scheme>                 <!-- Add net shortwave surface flux to host model surface fluxes -->
+      <!-- **************************** -->
+      <scheme>check_energy_chng</scheme>              <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>tropopause_output</scheme>              <!-- Calculate tropopause diagnostic variables, and output them to history file -->
+      <scheme>cam_export</scheme>                     <!-- Add various physics state variables to host model surface fluxes -->
+      <scheme>diag_export</scheme>                    <!-- Output various host model surface fluxes to history file -->
+    </timesplit>
+  </group>
+  <group name="physics_ac">
+    <timesplit>
+      <!--cam6:  diffusion=CLUBB, chem=trop_mam4 -->
+      <scheme>flux_avg_run</scheme>                   <!-- Smooth/average surface fluxes, but only if phys_do_flux_avg is True -->
+      <scheme>physics_state_check</scheme>            <!-- Only if state_debug_checks is True. This scheme only looks for infs/nans, and kills the model if found -->
+      <scheme>calc_flx_net</scheme>                   <!-- Accumulate net surface fluxes, which is necessary for spectral dycores -->
+      <!-- Chemistry emissisons -->
+      <!-- **************************** -->
+      <scheme>aero_model_emissions</scheme>           <!-- Calculate aerosol emissions, and add them to the host model's surface inputs -->
+      <scheme>calc_MEGAN_fluxes</scheme>              <!-- Calculate MEGAN fluxes, and add them to the host model's surface inputs and history files -->
+      <scheme>set_srf_emissions</scheme>              <!-- Calculate surface chemistry emissions -->
+      <scheme>srf_emis_diag_output</scheme>           <!-- Add surface chemistry emissions to host model's surface inputs and history files -->
+      <scheme>fire_emissions_srf</scheme>             <!-- Calculate fire emissions, and add to host model's surface inputs -->
+      <!-- **************************** -->
+      <scheme>carma_emission_tend</scheme>            <!-- Calculate CARMA emissions.  Only matters if CARMA is active -->
+      <scheme>check_tracers_init</scheme>             <!-- Initalize tracer/constituent mass checker -->
+      <!-- Negative moisture/tracer check -->
+      <!-- **************************** -->
+      <scheme>qneg4</scheme>                          <!-- Modify surface moisture and heat fluxes to prevent negative moisture values -->
+      <scheme>qneg4_diag_output</scheme>              <!-- Output qneg4 diagnostics (i.e. the "outfld" calls) -->
+      <!-- **************************** -->
+      <scheme>aoa_tracers_timestep_tend</scheme>      <!-- Calculate age of air tracer tendencies.  Also output tendencies to history file -->
+      <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
+      <scheme>co2_cycle_set_ptend</scheme>            <!-- Calculate CO2 tendencies.  Only matters if co2_flag or co2_readFlux_aircraft is True -->
+      <!-- Atmospheric Chemistry (MOZART), only matters if chem_is_active is True -->
+      <!-- **************************** -->
+      <scheme>short_lived_species_writeic</scheme>    <!-- Write initial values for short-lived chemical species to history file, if requested by user -->
+      <scheme>get_curr_calday</scheme>                <!-- Determine day of year -->
+      <scheme>chem_tropopause_find</scheme>           <!-- Determine tropopause height (specific tropopause calculation depends on chem_use_chemtrop) -->
+      <scheme>neu_wetdep_tend</scheme>                <!-- Calculate wet deposition rates via the "Neu" scheme -->
+      <scheme>chem_calc_cldw</scheme>                 <!-- Calculate total cloud water mass and droplet number -->
+      <scheme>gas_phase_chemdr</scheme>               <!-- Calculate gas-phase chemical reaction tendencies -->
+      <scheme>nitro_srf_flx</scheme>                  <!-- Add nitrogen surface fluxes to host model surface fluxes (managed by registry/framework?) -->
+      <scheme>chem_diag_output</scheme>               <!-- Calculate chemistry diagnostic variables, and output them to history file -->
+      <!-- **************************** -->
+      <scheme>check_energy_chng</scheme>              <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
+      <!-- Vertical diffusion -->
+      <!-- **************************** -->
+      <scheme>set_dry_to_wet</scheme>                 <!-- Convert mixing ratios from dry air to air + water vapor -->
+      <scheme>tint_calc</scheme>                      <!-- Interpolate air temperature to layer interface levels -->
+      <scheme>ubc_get_vals</scheme>                   <!-- Calcuate upper-level boundary conditions (depends on chemistry and model-top choice) -->
+      <scheme>set_top_tint_val</scheme>               <!-- Calculate air temperature at top interface level -->
+      <scheme>pres_1D_convert</scheme>                <!-- Convert pressure and dry pressure into 1-D variables (managed by framework?) -->
+      <scheme>rairi_calc</scheme>                     <!-- Interpolate gas constant (rair) at layer interface levels.  Only matters if using WACCM-X -->
+      <scheme>rhoi_calc</scheme>                      <!-- Interpolate air density and dry air density to layer interface levels -->
+      <scheme>compute_tms</scheme>                    <!-- Calculate Turbulent Mountain Stress (TMS) tendency -->
+      <scheme>tms_diag_output</scheme>                <!-- Calculate TMS diangostic variables, and output them to history file -->
+      <scheme>compute_blj</scheme>                    <!-- Calculate Sub-Grid Orgraphic (SGO) drag via Beljaars parameterization -->
+      <scheme>blj_diag_output</scheme>                <!-- Calculate SGO diagnostic variables, and output them to history file -->
+      <scheme>theta_calc</scheme>                     <!-- Calculate potential temperature (managed by registry/framework?) -->
+      <scheme>virtem</scheme>                         <!-- Calculate virtual temperature (managed by registry/framework?) -->
+      <scheme>calc_ustar</scheme>                     <!-- Calculate friction velocity -->
+      <scheme>calc_obklen</scheme>                    <!-- Calculate Obhukov length -->
+      <scheme>pbl_diag_calc</scheme>                  <!-- Calculate PBL diagnositc variables, if do_pbl_diags is False -->
+      <scheme>dse_top_calc</scheme>                   <!-- Calculate top-level dry static energy, but only if do_molec_diff is True and WACCM-X is False -->
+      <scheme>compute_molec_diff_wet</scheme>         <!-- Calculate molecular diffusion of wet atmospheric constituents, if do_molec_diff is True -->
+      <scheme>compute_vdiff_wet</scheme>              <!-- Calculate the vertical (eddy) diffusion of wet atmospheric constituents -->
+      <scheme>compute_molec_diff_dry</scheme>         <!-- Calculate molecular diffusion of dry atmospheric constituents, if do_molec_diff is True -->
+      <scheme>compute_vdiff_dry</scheme>              <!-- Calculate the vertical (eddy) diffusion of dry atmospheric constituents -->
+      <scheme>aero_srf_flx_add</scheme>               <!-- Add surface aerosol fluxes to bottom model layer, but only if prog_modal_aero is True -->
+      <scheme>diff_flux_diag</scheme>                 <!-- Calculate diffusion variable diagnostics, if do_pbl_diags is False (is that correct?) -->
+      <scheme>diff_flux_tend_dry</scheme>             <!-- Calculate vertical diffusion tendencies for "dry" quantities, and send them back to host model -->
+      <scheme>set_wet_to_dry</scheme>                 <!-- Convert mixing ratios from air + water vapor to dry air -->
+      <scheme>pbl_diag_calc</scheme>                  <!-- Calculate PBL diagnositc variables, if do_pbl_diags is False -->
+      <scheme>diff_mass_check</scheme>                <!-- Check mass conservation after vertical diffusion, and send error messages if check fails -->
+      <scheme>pbl_output</scheme>                     <!-- Write PBL diagnostic variables to history files -->
+      <scheme>pres_1D_finalize</scheme>               <!-- Deallocate 1-D pressure variables -->
+      <!-- **************************** -->
+      <scheme>waccmx_phys_mspd_tend</scheme>          <!-- Only if WACCM-X "ionosphere" or "neutral" is being used -->
+      <scheme>rayleigh_friction_tend</scheme>         <!-- Calculate Rayleigh friction tendency -->
+      <scheme>check_energy_chng</scheme>              <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
+      <!-- Aerosol dry deposition -->
+      <!-- **************************** -->
+      <scheme>calcram</scheme>                        <!-- Calculate aerodynamic resistance and friction velocity -->
+      <scheme>calcram_diag_output</scheme>            <!-- Write aerodynamic resistance and friction velocity to history file -->
+      <scheme>calc_atm_density</scheme>               <!-- Calculate atmospheric density -->
+      <subcyle loop="jvlc34">                         <!-- loop over vlc array index values 3 and 4 -->
+        <scheme>modal_aero_depvel_part</scheme>       <!-- Calculate dry deposition velocity for cloud droplets -->
+      </subcycle>
+      <subcycle loop="ntot_amode">                    <!-- Loop over aerosol modes -->
+        <subcycle loop="lphase">                      <!-- Loop over aerosol phase types (interstitial vs cloud-borne -->
+          <scheme>calc_aero_vars</scheme>             <!-- Calculate aerosol mean wet radius and other properties -->
+          <subcycle loop="jvlc12">                    <!-- loop over vlc array index values 1 and 2 -->
+            <scheme>modal_aero_depvel_part</scheme>   <!-- Calculate dry deposition velocity for interstial aerosols -->
+          </subcycle>
+          <scheme>aero_tracer_indx</scheme>           <!-- Determine aerosol tracer index (managed by registry/framework?) -->
+          <scheme>depvel_m_to_pa</scheme>             <!-- Convert the deposition velocity from m/s to Pa/s, and write to history file (maanged by registry/framework?) -->
+          <scheme>dust_sediment_tend</scheme>         <!-- Calculate host model tendencies and surface fluxes from dry deposition -->
+          <scheme>drydep_diag_output</scheme>         <!-- Calculate dry deposition diagnostic variables, and output them to history file -->
+        </subcycle>
+      </subcycle>
+      <scheme>set_srf_drydep</scheme>                 <!-- Add dry deposition surface fluxes to host model, if aerodep_flx_prescribed is False -->
+      <!-- **************************** -->
+      <scheme>carma_timestep_tend</scheme>            <!-- Calculate CARMA microphysics.  Only matters if CARMA is active -->
+      <scheme>charge_balance</scheme>                 <!-- Enforce charge nuetrality, if chemistry simulates electrons -->
+      <!-- Gravit wave tendencies -->
+      <!-- **************************** -->
+      <!-- This interface depends heavily
+           on namelist inputs, with entire
+           blocks of code being used (or not)
+           depending on said namelist choices.
+           However, the general structure of these
+           code blocks is more or less the same,
+           so a "generic" scheme set is included
+           here, which will need to be expanded
+           out once "if-statement" like dependencies
+           can be added to suite definition files
+           like this one -->
+      <scheme>physics_state_copy</scheme>
+      <scheme>set_dry_to_wet</scheme>                  <!-- Convert mixing ratios from dry air to air + water vapor -->
+      <scheme>pres_1D_convert</scheme>                 <!-- Convert pressure and dry pressure into 1-D variables (managed by framework?) -->
+      <scheme>gw_prof</scheme>                         <!-- Calculate layer interface densities and Brunt-Viasala frequencies (combine with other schemes?) -->
+      <!-- Generic gravity wave scheme order  -->
+      <!-- +++++++++++++++++++++++++ -->
+      <scheme>effgw_calc</scheme>                      <!-- Calculate the efficiency of gravity wave momentum transfer -->
+      <scheme>gw_src_calc</scheme>                     <!-- Determine gravity wave sources -->
+      <scheme>gw_drag_prof</scheme>                    <!-- Solve for the drag profile with the gravity wave spectrum -->
+      <scheme>calc_taucd</scheme>                      <!-- Project stress into directional components -->
+      <scheme>egwdffi_tot_calc</scheme>                <!-- add diffusion coefficients (manageable by registry/framework?) -->
+      <scheme>momentum_flux_calc</scheme>              <!-- Calculate momentum fluxes/wind tendencies -->
+      <scheme>energy_change</scheme>                   <!-- Calculate atmospheric energy change -->
+      <scheme>energy_fixer</scheme>                    <!-- Ensure energy conservation -->
+      <scheme>gw_cam_update</scheme>                   <!-- Placeholder for CAM gravity wave ptend and diagnostic output calculations -->
+      <!-- +++++++++++++++++++++++++ -->
+      <scheme>pres_1D_finalize</scheme>                <!-- Deallocate 1-D pressure variables -->
+      <!-- **************************** -->
+      <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>qbo_relax</scheme>                       <!-- Relax zonal winds towards QBO sequence.  Only matters if host model is WACCM or WACCM-X -->
+      <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>lunar_tides_tend</scheme>                <!-- Calculate horizontal wind tendencies due to M2 lunar tide, but only if apply_lunar_tides is True -->
+      <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
+      <scheme>iondrag_calc</scheme>                    <!-- Calculate ion drag and joule heating tendencies.  Only matters if host model is WACCM or WACCM-X -->
+      <scheme>waccmx_phys_ion_elec_temp_tend</scheme>  <!-- Calculate ionosphere tendencies.  Only matters if host model is WACCM-X in 'ionosphere' mode -->
+      <scheme>calc_te_and_aam_budgets</scheme>         <!-- Managed by host model? -->
+      <scheme>charge_balance</scheme>                  <!-- Enforce charge nuetrality, if chemistry simulates electrons and host model is WACCM-X in 'ionosphere' mode -->
+      <scheme>nudging_timestep_tend</scheme>           <!-- Apply nudging to horizontal winds, heat, and water vapor, and output diagnostics, but only if nudging is turned on. -->
+      <scheme>set_dry_to_wet</scheme>                  <!-- Only matters if dycore is FV (LR) or SE -->
+      <!-- Dry air mass adjuster -->                   <!-- Only matters if dycore is FV (LR), otherwise this calculation is purely diagnostic -->
+      <!-- **************************** -->
+      <scheme>qfac_state_adjust</scheme>               <!-- Adjust state variables based off the change in water vapor -->
+      <scheme>geopotential_dse</scheme>                <!-- Calculate the temperatue and geopotential height using pressure and dry static energy -->
+      <!-- **************************** -->
+      <scheme>calc_te_and_aam_budgets</scheme>         <!-- Managed by host model? -->
+      <scheme>dtcore_reset</scheme>                    <!-- Reset "dtcore" variable to equal temperature -->
+      <scheme>diag_phys_tend_writeout</scheme>         <!-- Calculate physics diagnostic variables, and output them to history file -->
+      <scheme>clybry_fam_set</scheme>                  <!-- Set ClOy and BrOy mass mixig ratios. Only matters if chemistry package with Cly and Bry is used -->
+    </timesplit>
+  </group>
+</suite>

--- a/suite_cam6.xml
+++ b/suite_cam6.xml
@@ -8,8 +8,7 @@
       <scheme>clybry_fam_adj</scheme>      <!-- Only matters if chemistry package with Cly and Bry is used -->
       <!-- Negative moisture/tracer check -->
       <!-- **************************** -->
-      <scheme>qneg3</scheme>                    <!-- This scheme modifies the state directly.  Combine with state check? -->
-      <scheme>qneg3_diag_output</scheme>        <!-- Scheme to output qneg diagnostics (i.e. the "outfld" calls) -->
+      <scheme>qneg3</scheme>               <!-- This scheme modifies the state directly.  Combine with state check? -->
       <!-- **************************** -->
       <scheme>physics_state_check</scheme>      <!-- Only if state_debug_checks is True. This scheme only looks for infs/nans, and kills the model if found. -->
       <scheme>diag_state_b4_phys_write</scheme> <!-- Diagnostics -->
@@ -26,14 +25,11 @@
       <scheme>calc_dtcore</scheme>             <!-- diagnostic calculation.  Could likely be included in energy fixer scheme. -->
       <!-- Dry adiabatic adjustment  -->
       <!-- **************************** -->
-      <scheme>physics_state_copy</scheme>      <!-- Technically only need T and q here, not entire state -->
-      <scheme>dadadj_calc</scheme>             <!-- Actual dry adiabatic adjustment scheme -->
-      <scheme>dadadj_cam_update</scheme>       <!-- Placeholder for CAM ptend calculations -->
-      <scheme>physics_state_dealloc</scheme>
+      <!-- Technically only needs temperature and humidity as inputs -->
+      <scheme>dadadj_calc_update</scheme>      <!-- Actual dry adiabatic adjustment scheme, with placeholders for CAM ptend calculations -->
       <!-- **************************** -->
       <!-- Zhang-Macfarlane deep convection scheme -->
       <!-- **************************** -->
-      <scheme>physics_state_copy</scheme>
       <scheme>zm_convr</scheme>                 <!-- Actual deep convection routine -->
       <scheme>zm_convr_cam_update</scheme>      <!-- Placeholder for CAM ptend and diagnostic output calculations -->
       <scheme>zm_conv_evap</scheme>             <!-- Actual ZM rain evaporation scheme -->
@@ -42,7 +38,6 @@
       <scheme>momtran_cam_update</scheme>       <!-- Placeholder for CAM ptend and diagnostic output calculations -->
       <scheme>convtran</scheme>                 <!-- Actual ZM convective transport scheme, for constituents in cnst_is_convtran1 -->
       <scheme>convtran_cam_update</scheme>      <!-- Placeholder for CAM ptend and diagnostic output calculations -->
-      <scheme>physics_state_dealloc</scheme>
       <!-- **************************** -->
       <scheme>check_energy_chng</scheme>        <!-- Global integral checker required for certain diagnostic outputs -->
       <scheme>check_tracers_chng</scheme>       <!-- Global tracer mass checker that kills model if error is large enough. -->
@@ -56,7 +51,6 @@
             of host model inputs.  Thus they can likely be
             managed by the framework itself, and won't need
             their own scheme calls.-->
-        <scheme>physics_state_copy</scheme>
         <scheme>set_dry_to_wet</scheme>               <!-- Convert mixing ratios from dry air to air + water vapor -->
         <scheme>grid_size</scheme>                    <!-- Calculate grid-cell size (not sure if this will be managed by registry/interface?) -->
         <scheme>clubb_dtime_calc</scheme>             <!-- Calculate CLUBB time-step as function of host model time-step -->
@@ -85,7 +79,6 @@
         <scheme>conv_cond_detrain_cam_update</scheme> <!-- Placeholder for CAM ptend and diagnostic output calculations -->
         <scheme>set_wet_to_dry</scheme>               <!-- Convert mixing ratios from air + water vapor to dry air -->
         <scheme>clubb_diag_output</scheme>            <!-- Calculate numerous different CLUBB diagnostic variables, and output them to history file -->
-        <scheme>physics_state_dealloc</scheme>        <!-- This never actually happens in the current code (at least from what I could tell).  Bug? -->
         <!-- **************************** -->
         <scheme>check_energy_chng</scheme>            <!-- Global integral checker required for certain diagnostic outputs -->
         <subcol gen="subcol_generator_name" avg="subcol_averager_name">
@@ -99,7 +92,6 @@
             <!-- **************************** -->
             <scheme>micro_mg_get_cols2_0</scheme>     <!-- Determine packed columns used by the MG2 microphysics schemes -->
             <scheme>calc_incloud_LWP</scheme>         <!-- Calculate in-cloud Liquid Water Path (LWP) before MG2 is run -->
-            <scheme>physics_state_copy</scheme>
             <scheme>micro_calc_tropopause</scheme>    <!-- Calculate the cold-point tropopause for use by the microphysics -->
             <scheme>mg_variable_packer</scheme>       <!-- Pack grid-domain variables together to reduce loop sizes (necessary?) -->
             <scheme>micro_mg_tend2_0</scheme>         <!-- Actual MG2 cloud micro-physics parameterization scheme -->
@@ -123,7 +115,6 @@
             <scheme>calc_micro_column_vars</scheme>   <!-- Calculate Liquid Water Path (LWP) and net column condensation -->
             <scheme>calc_prec_efficiency</scheme>     <!-- Calculate precipitation efficiency -->
             <scheme>micro_diag_output</scheme>        <!-- Calculate microphysics diagnostic variables, and output them to history file -->
-            <scheme>physics_state_dealloc</scheme>
             <!-- **************************** -->
             <!-- SILHS subcolumn covariance -->
             <!-- **************************** -->
@@ -248,8 +239,7 @@
       <scheme>check_tracers_init</scheme>             <!-- Initalize tracer/constituent mass checker -->
       <!-- Negative moisture/tracer check -->
       <!-- **************************** -->
-      <scheme>qneg4</scheme>                          <!-- Modify surface moisture and heat fluxes to prevent negative moisture values -->
-      <scheme>qneg4_diag_output</scheme>              <!-- Output qneg4 diagnostics (i.e. the "outfld" calls) -->
+      <scheme>qneg4</scheme>                          <!-- Modify surface moisture and heat fluxes to prevent negative moisture values, and output diagnostics -->
       <!-- **************************** -->
       <scheme>aoa_tracers_timestep_tend</scheme>      <!-- Calculate age of air tracer tendencies.  Also output tendencies to history file -->
       <scheme>check_tracers_chng</scheme>             <!-- Global tracer mass checker that kills model if error is large enough. -->
@@ -273,7 +263,6 @@
       <scheme>tint_calc</scheme>                      <!-- Interpolate air temperature to layer interface levels -->
       <scheme>ubc_get_vals</scheme>                   <!-- Calcuate upper-level boundary conditions (depends on chemistry and model-top choice) -->
       <scheme>set_top_tint_val</scheme>               <!-- Calculate air temperature at top interface level -->
-      <scheme>pres_1D_convert</scheme>                <!-- Convert pressure and dry pressure into 1-D variables (managed by framework?) -->
       <scheme>rhoi_calc</scheme>                      <!-- Interpolate air density and dry air density to layer interface levels -->
       <scheme>compute_tms</scheme>                    <!-- Calculate Turbulent Mountain Stress (TMS) tendency -->
       <scheme>tms_diag_output</scheme>                <!-- Calculate TMS diangostic variables, and output them to history file -->
@@ -296,7 +285,6 @@
       <scheme>pbl_diag_calc</scheme>                  <!-- Calculate PBL diagnositc variables, if do_pbl_diags is False -->
       <scheme>diff_mass_check</scheme>                <!-- Check mass conservation after vertical diffusion, and send error messages if check fails -->
       <scheme>pbl_output</scheme>                     <!-- Write PBL diagnostic variables to history files -->
-      <scheme>pres_1D_finalize</scheme>               <!-- Deallocate 1-D pressure variables -->
       <!-- **************************** -->
       <scheme>rayleigh_friction_tend</scheme>         <!-- Calculate Rayleigh friction tendency -->
       <scheme>check_energy_chng</scheme>              <!-- Global integral checker required for certain diagnostic outputs -->
@@ -337,9 +325,7 @@
            out once "if-statement" like dependencies
            can be added to suite definition files
            like this one -->
-      <scheme>physics_state_copy</scheme>
       <scheme>set_dry_to_wet</scheme>                  <!-- Convert mixing ratios from dry air to air + water vapor -->
-      <scheme>pres_1D_convert</scheme>                 <!-- Convert pressure and dry pressure into 1-D variables (managed by framework?) -->
       <scheme>gw_prof</scheme>                         <!-- Calculate layer interface densities and Brunt-Viasala frequencies (combine with other schemes?) -->
       <!-- Generic gravity wave scheme order  -->
       <!-- +++++++++++++++++++++++++ -->
@@ -353,9 +339,7 @@
       <scheme>energy_fixer</scheme>                    <!-- Ensure energy conservation -->
       <scheme>gw_cam_update</scheme>                   <!-- Placeholder for CAM gravity wave ptend and diagnostic output calculations -->
       <!-- +++++++++++++++++++++++++ -->
-      <scheme>pres_1D_finalize</scheme>                <!-- Deallocate 1-D pressure variables -->
       <!-- **************************** -->
-      <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
       <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->
       <scheme>lunar_tides_tend</scheme>                <!-- Calculate horizontal wind tendencies due to M2 lunar tide, but only if apply_lunar_tides is True -->
       <scheme>check_energy_chng</scheme>               <!-- Global integral checker required for certain diagnostic outputs -->


### PR DESCRIPTION
First pass at creating a CAM6 suite definition file.  A few relevant notes and questions:

1.  I wasn't sure if the ZM convective microphysics scheme is part of CAM6, and thus should be included in this file.  I have left it out for now, but can certainly add it in if need be.

2.  I didn't include any timing calls (e.g. "t_startf"), as I wasn't sure if that is managed by the CCPP framework, or by the host model.

3.  I Added schemes which should only matter if WACCM, WACCM-X, CARMA, and/or MOZART (atmospheric chemistry) are used.  It is unclear to me, though, if they should be in the CAM6 suite definition file, or if they should have their own definition files (e.g. suite_waccm.xml).

4.  This suite definition file needs to be updated whenever the use of logical variables becomes allowed, as many schemes depend on certain namelist settings, while other schemes are embedded inside select-case statements with multiple different possibilities.

Finally, I should also note that I haven't done any sort of testing on this file.  If there are any sort of xmllint or other CCPP tests that I should run before merging just let me know.  Thanks!