### PR TITLE
Metadata consistency fixes

### DIFF
--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -1,3 +1,6 @@
+[ccpp-table-properties]
+  name = kessler
+  type = scheme
 [ccpp-arg-table]
   name = kessler_init
   type = scheme
@@ -25,7 +28,7 @@
   kind = kind_phys
   intent = in
 [ rair_in ]
-  standard_name = gas_constant_dry_air 
+  standard_name = gas_constant_of_dry_air
   units =  J kg-1 K-1
   dimensions = ()
   type = real
@@ -228,7 +231,7 @@
   intent = out
 [ relhum ]
   standard_name = relative_humidity
-  units = percent 
+  units = percent
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real
   kind = kind_phys

--- a/kessler/kessler_update.meta
+++ b/kessler/kessler_update.meta
@@ -1,3 +1,6 @@
+[ccpp-table-properties]
+  name = kessler_update
+  type = scheme
 [ccpp-arg-table]
   name = kessler_update_init
   type = scheme

--- a/utilities/geopotential_t.meta
+++ b/utilities/geopotential_t.meta
@@ -1,3 +1,6 @@
+[ccpp-table-properties]
+  name = geopotential_t
+  type = scheme
 [ccpp-arg-table]
   name = geopotential_t_run
   type = scheme

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -1,3 +1,6 @@
+[ccpp-table-properties]
+  name = temp_to_potential_temp
+  type = scheme
 [ccpp-arg-table]
   name = temp_to_potential_temp_run
   type = scheme
@@ -55,6 +58,9 @@
   intent = out
   optional = F
 #####################################################################
+[ccpp-table-properties]
+  name = potential_temp_to_temp
+  type = scheme
 [ccpp-arg-table]
   name = potential_temp_to_temp_run
   type = scheme
@@ -109,6 +115,9 @@
   dimensions = ()
   intent = out
 #########################################################
+[ccpp-table-properties]
+  name = pres_to_density_dry
+  type = scheme
 [ccpp-arg-table]
   name = pres_to_density_dry_init
   type = scheme
@@ -201,6 +210,9 @@
    intent = out
    optional = F
 #########################################################
+[ccpp-table-properties]
+  name = calc_exner
+  type = scheme
 [ccpp-arg-table]
   name = calc_exner_init
   type = scheme
@@ -284,6 +296,9 @@
    intent = out
    optional = F
 #########################################################
+[ccpp-table-properties]
+  name = wet_to_dry
+  type = scheme
 [ccpp-arg-table]
   name = wet_to_dry_run
   type = scheme
@@ -357,6 +372,9 @@
    optional = F
 
 #########################################################
+[ccpp-table-properties]
+  name = dry_to_wet
+  type = scheme
 [ccpp-arg-table]
   name = dry_to_wet_run
   type = scheme


### PR DESCRIPTION
This PR mostly updates the metadata standard. It also corrects one standard name, `gas_constant_of_dry_air`.
fixes #25 