### PR TITLE
fix constituent stdnames in state_converters.meta

### DIFF
--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -379,7 +379,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qc ]
-  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air
+  standard_name = cloud_liquid_water_mixing_ratio_of_moist_air
   long_name = Mass mixing ratio of cloud liquid water / moist_air
   advected = True
   type = real | kind = kind_phys
@@ -441,7 +441,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_water_mixing_ratio_wrt_moist_air
+  standard_name = rain_water_mixing_ratio
   long_name = Mass mixing ratio of rain / moist air
   advected = True
   type = real | kind = kind_phys
@@ -570,7 +570,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qc ]
-  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air
+  standard_name = cloud_liquid_water_mixing_ratio_of_moist_air
   long_name = Mass mixing ratio of cloud liquid water / moist air
   type = real | kind = kind_phys
   units = kg kg-1
@@ -631,7 +631,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_water_mixing_ratio_wrt_moist_air
+  standard_name = rain_water_mixing_ratio
   long_name = Mass mixing ratio of rain / moist_air
   type = real | kind = kind_phys
   units = kg kg-1


### PR DESCRIPTION
There is a mismatch in standard names for the following:

- cloud_liquid_water_mixing_ratio_wrt_moist_air vs cloud_liquid_water_mixing_ratio_of_moist_air
- rain_water_mixing_ratio vs rain_water_mixing_ratio_wrt_moist_air

The only place that the first names were used was in state_converters.meta. Switching those to the second names listed for consistency. The corrected names match those listed in https://github.com/NCAR/CAMDEN/wiki/Metadata-standard-names