### PR TITLE
 Update standard and function names plus major code clean-up

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -4,7 +4,7 @@ Tag name: atmos_phys0_01_000
 Originator(s): nusbaume
 Date: 9 Sep 2023
 One-line Summary: Update standard and function names plus major code clean-up
-Github PR URL: https://github.com/NCAR/atmospheric_physics/pull/XXX
+Github PR URL: https://github.com/NCAR/atmospheric_physics/pull/67
 
 Purpose of changes (include the issue number and title text for each relevant GitHub issue):
 
@@ -24,65 +24,49 @@ This PR fixes the following NCAR/atmospheric_physics Github issues:
 
 Code reviewed by: cacraig, peverwhee, mwaxmonsky
 
-List all files eliminated:
+List all existing files that have been added (A), modified (M), or deleted (D),
+and describe the changes:
 
-utilities/geopotential_t.F90 - Replaced with utilities/geopotential_temp.F90
-utilities/geopotential_t.meta - Replaced with utilities/geopotential_temp.meta
-
-List all files added and what they do:
-
-utilities/geopotential_temp.F90 - New geopotential calculation routine which uses
-                                  generalized virtual temperature (i.e. all
-                                  thermodynamically active species).
-utilities/geopotential_temp.meta - Metdata file for new "geopotential_temp.F90" CCPP scheme.
-
-List all existing files that have been modified, and describe the changes:
-
-held_suarez/held_suarez_1994.F90         - Code cleanup
-held_suarez/held_suarez_1994.meta        - Updated variable standard names and removed unused variables
-kessler/kessler.F90                      - Code cleanup and bug fixes
-kessler/kessler.meta                     - Updated variable standard names and removed unused variables
-kessler/kessler_update.F90               - Code cleanup
-kessler/kessler_update.meta              - Updated variable standard names and did some metadata cleanup
-suite_held_suarez_1994.xml               - Updated scheme names, and modified scheme list to better match CAM.
-suite_kessler.xml                        - Updated scheme names.
-utilities/physics_tendency_updaters.F90  - Updated variable names and dimensioning
-utilities/physics_tendency_updaters.meta - Updated variable standard names
-utilities/qneg.F90                       - Code cleanup
-utilities/qneg.meta                      - Updated variable standard names and removed unused variables
-utilities/state_converters.F90           - Code cleanup and updated variable/scheme names.
-utilities/state_converters.meta          - Updated variable standard names and scheme names,
-                                           and removed unused variables.
-utilities/static_energy.F90              - Code cleanup and updated variable dimensioning
-utilities/static_energy.meta             - Updated variable standard names
-
-List all standard names currently not in the CCPPStandardNames dictionary:
-
-    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
-    - reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
-    - heating_rate
-    - tendency_of_northward_wind
-    - composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
-    - tendency_of_eastward_wind
-    - scheme_name
-    - rain_mixing_ratio_wrt_dry_air
-    - density_of_dry_air
-    - density_of_fresh_liquid_water_at_0c
-    - composition_dependent_gas_constant_of_dry_air
-    - tendency_of_northward_wind_due_to_model_physics
-    - tendency_of_eastward_wind_due_to_model_physics
-    - number_of_ccpp_constituents
-    - flag_for_mpi_root
-    - ccpp_constituent_minimum_values
-    - log_output_unit
-    - ccpp_constituents
-    - ccpp_constituent_properties
-    - print_qneg_warn
-    - lagrangian_vertical_coordinate
-    - ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one
-    - geopotential_height_wrt_surface_at_interface
-    - rain_mixing_ratio_wrt_moist_air_and_condensed_water
-    - cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+A       doc/ChangeLog
+  - So future developers can know the development history
+M       held_suarez/held_suarez_1994.F90
+  - Code cleanup
+M       held_suarez/held_suarez_1994.meta
+  - Updated variable standard names and removed unused variables
+M       kessler/kessler.F90
+  - Code cleanup and bug fixes
+M       kessler/kessler.meta
+  - Updated variable standard names and did some metadata cleanup
+M       kessler/kessler_update.F90
+  - Code cleanup
+M       kessler/kessler_update.meta
+  - Updated variable standard names and did some metadata cleanup
+M       suite_held_suarez_1994.xml
+  - Updated scheme names, and modified scheme list to better match CAM
+M       suite_kessler.xml
+  - Updated scheme names
+D       utilities/geopotential_t.F90
+  - Replaced with utilities/geopotential_temp.F90
+A       utilities/geopotential_temp.F90
+  - New geopotential calculation routine which uses generalized virtual temperature,
+    i.e. all thermodynamically active species
+M       utilities/physics_tendency_updaters.F90
+  - Updated variable names and dimensioning
+M       utilities/physics_tendency_updaters.meta
+  - Updated variable standard names
+M       utilities/qneg.F90
+  - Code cleanup
+M       utilities/qneg.meta
+  - Updated variable standard names and removed unused variables
+M       utilities/state_converters.F90
+  - Code cleanup and updated variable/scheme names
+M       utilities/state_converters.meta
+  - Updated variable standard names and scheme names,
+    and removed unused variables.
+M       utilities/static_energy.F90
+  - Code cleanup and updated variable dimensioning
+M       utilities/static_energy.meta
+  - Updated variable standard names
 
 List and Describe any test failures: No known test failures.
 

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,0 +1,93 @@
+===============================================================
+
+Tag name: atmos_phys0_01_000
+Originator(s): nusbaume
+Date: 9 Sep 2023
+One-line Summary: Update standard and function names plus major code clean-up
+Github PR URL: https://github.com/NCAR/atmospheric_physics/pull/XXX
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+
+The main purpose of this PR is to update the CCPP standard names to match the
+internal AMP agreed-upon names, as well as rename some of the physics routines
+to make them less ambigious and more accurate.  Along with these changes,
+significant code cleanup was performed along with some minor bug fixes,
+with the goal being to produce bit-for-bit results using the same repo
+version in both CAM and CAM-SIMA.
+
+This PR fixes the following NCAR/atmospheric_physics Github issues:
+
+#60 -> Required atmospheric physics updates
+#61 -> "calc_exner_run" routine should be given reference pressure argument
+#62 -> Need to update geopotential_t to use "generalized" virtual temperature
+#64 -> held_suarez_1994 SDF needs the geopotential_t scheme.
+
+Code reviewed by: cacraig, peverwhee, mwaxmonsky
+
+List all files eliminated:
+
+utilities/geopotential_t.F90 - Replaced with utilities/geopotential_temp.F90
+utilities/geopotential_t.meta - Replaced with utilities/geopotential_temp.meta
+
+List all files added and what they do:
+
+utilities/geopotential_temp.F90 - New geopotential calculation routine which uses
+                                  generalized virtual temperature (i.e. all
+                                  thermodynamically active species).
+utilities/geopotential_temp.meta - Metdata file for new "geopotential_temp.F90" CCPP scheme.
+
+List all existing files that have been modified, and describe the changes:
+
+held_suarez/held_suarez_1994.F90         - Code cleanup
+held_suarez/held_suarez_1994.meta        - Updated variable standard names and removed unused variables
+kessler/kessler.F90                      - Code cleanup and bug fixes
+kessler/kessler.meta                     - Updated variable standard names and removed unused variables
+kessler/kessler_update.F90               - Code cleanup
+kessler/kessler_update.meta              - Updated variable standard names and did some metadata cleanup
+suite_held_suarez_1994.xml               - Updated scheme names, and modified scheme list to better match CAM.
+suite_kessler.xml                        - Updated scheme names.
+utilities/physics_tendency_updaters.F90  - Updated variable names and dimensioning
+utilities/physics_tendency_updaters.meta - Updated variable standard names
+utilities/qneg.F90                       - Code cleanup
+utilities/qneg.meta                      - Updated variable standard names and removed unused variables
+utilities/state_converters.F90           - Code cleanup and updated variable/scheme names.
+utilities/state_converters.meta          - Updated variable standard names and scheme names,
+                                           and removed unused variables.
+utilities/static_energy.F90              - Code cleanup and updated variable dimensioning
+utilities/static_energy.meta             - Updated variable standard names
+
+List all standard names currently not in the CCPPStandardNames dictionary:
+
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
+    - heating_rate
+    - tendency_of_northward_wind
+    - composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
+    - tendency_of_eastward_wind
+    - scheme_name
+    - rain_mixing_ratio_wrt_dry_air
+    - density_of_dry_air
+    - density_of_fresh_liquid_water_at_0c
+    - composition_dependent_gas_constant_of_dry_air
+    - tendency_of_northward_wind_due_to_model_physics
+    - tendency_of_eastward_wind_due_to_model_physics
+    - number_of_ccpp_constituents
+    - flag_for_mpi_root
+    - ccpp_constituent_minimum_values
+    - log_output_unit
+    - ccpp_constituents
+    - ccpp_constituent_properties
+    - print_qneg_warn
+    - lagrangian_vertical_coordinate
+    - ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one
+    - geopotential_height_wrt_surface_at_interface
+    - rain_mixing_ratio_wrt_moist_air_and_condensed_water
+    - cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+
+List and Describe any test failures: No known test failures.
+
+Summarize any changes to answers: bit-for-bit unchanged
+
+NOTE: This is the first ChangeLog Entry.  All previous modifications or additions
+      are solely described in the git log and Github PR documentation.
+===============================================================

--- a/doc/ChangeLog_template
+++ b/doc/ChangeLog_template
@@ -1,0 +1,22 @@
+===============================================================
+
+Tag name:
+Originator(s):
+Date:
+One-line Summary:
+Github PR URL:
+
+Purpose of changes (include the issue number and title text for each relevant GitHub issue):
+
+This PR fixes the following NCAR/atmospheric_physics Github issues:
+
+Code reviewed by:
+
+List all existing files that have been added (A), modified (M), or deleted (D),
+and describe the changes:
+
+List and Describe any test failures:
+
+Summarize any changes to answers:
+
+===============================================================

--- a/doc/NamesNotInDictionary.txt
+++ b/doc/NamesNotInDictionary.txt
@@ -1,91 +1,86 @@
 
 #######################
 Date/time of when script was run:
-2023-09-22 14:17:13.744163
+2023-10-09 13:43:57.056889
 #######################
 
 Non-dictionary standard names found in the following metadata files:
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/held_suarez/held_suarez_1994.meta
+../NCAR_atmospheric_physics_fork/held_suarez/held_suarez_1994.meta
 
-    - tendency_of_eastward_wind
-    - heating_rate
-    - reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
-    - scheme_name
     - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - scheme_name
+    - reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
+    - heating_rate
+    - tendency_of_eastward_wind
     - composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
     - tendency_of_northward_wind
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/kessler/kessler_update.meta
+../NCAR_atmospheric_physics_fork/kessler/kessler_update.meta
 
     - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/kessler/kessler.meta
+../NCAR_atmospheric_physics_fork/kessler/kessler.meta
 
-    - density_of_dry_air
-    - density_of_fresh_liquid_water_at_0c
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
     - rain_mixing_ratio_wrt_dry_air
     - scheme_name
-    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
-    - composition_dependent_gas_constant_of_dry_air
+    - density_of_dry_air
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/static_energy.meta
+../NCAR_atmospheric_physics_fork/utilities/static_energy.meta
 
     - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/physics_tendency_updaters.meta
+../NCAR_atmospheric_physics_fork/utilities/physics_tendency_updaters.meta
 
-    - tendency_of_northward_wind_due_to_model_physics
-    - tendency_of_eastward_wind
-    - heating_rate
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
     - tendency_of_eastward_wind_due_to_model_physics
-    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - tendency_of_northward_wind_due_to_model_physics
+    - heating_rate
+    - tendency_of_eastward_wind
     - tendency_of_northward_wind
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/qneg.meta
+../NCAR_atmospheric_physics_fork/utilities/qneg.meta
 
-    - flag_for_mpi_root
-    - print_qneg_warn
-    - ccpp_constituent_minimum_values
-    - ccpp_constituent_properties
     - scheme_name
-    - log_output_unit
     - ccpp_constituents
+    - flag_for_mpi_root
+    - ccpp_constituent_minimum_values
+    - print_qneg_warn
     - number_of_ccpp_constituents
-
---------------------------
-
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/geopotential_temp.meta
-
-    - geopotential_height_wrt_surface_at_interface
-    - lagrangian_vertical_coordinate
     - ccpp_constituent_properties
-    - ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one
-    - composition_dependent_gas_constant_of_dry_air
-    - ccpp_constituents
-    - number_of_ccpp_constituents
+    - log_output_unit
 
 --------------------------
 
-/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/state_converters.meta
+../NCAR_atmospheric_physics_fork/utilities/geopotential_temp.meta
 
-    - density_of_dry_air
-    - cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
-    - rain_mixing_ratio_wrt_dry_air
+    - ccpp_constituents
+    - geopotential_height_wrt_surface_at_interface
+    - number_of_ccpp_constituents
+    - ccpp_constituent_properties
+    - lagrangian_vertical_coordinate
+
+--------------------------
+
+../NCAR_atmospheric_physics_fork/utilities/state_converters.meta
+
     - rain_mixing_ratio_wrt_moist_air_and_condensed_water
     - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
-    - composition_dependent_gas_constant_of_dry_air
+    - rain_mixing_ratio_wrt_dry_air
+    - density_of_dry_air
+    - cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
 
 #######################

--- a/doc/NamesNotInDictionary.txt
+++ b/doc/NamesNotInDictionary.txt
@@ -1,0 +1,91 @@
+
+#######################
+Date/time of when script was run:
+2023-09-22 14:17:13.744163
+#######################
+
+Non-dictionary standard names found in the following metadata files:
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/held_suarez/held_suarez_1994.meta
+
+    - tendency_of_eastward_wind
+    - heating_rate
+    - reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
+    - scheme_name
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
+    - tendency_of_northward_wind
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/kessler/kessler_update.meta
+
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/kessler/kessler.meta
+
+    - density_of_dry_air
+    - density_of_fresh_liquid_water_at_0c
+    - rain_mixing_ratio_wrt_dry_air
+    - scheme_name
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - composition_dependent_gas_constant_of_dry_air
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/static_energy.meta
+
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/physics_tendency_updaters.meta
+
+    - tendency_of_northward_wind_due_to_model_physics
+    - tendency_of_eastward_wind
+    - heating_rate
+    - tendency_of_eastward_wind_due_to_model_physics
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - tendency_of_northward_wind
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/qneg.meta
+
+    - flag_for_mpi_root
+    - print_qneg_warn
+    - ccpp_constituent_minimum_values
+    - ccpp_constituent_properties
+    - scheme_name
+    - log_output_unit
+    - ccpp_constituents
+    - number_of_ccpp_constituents
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/geopotential_temp.meta
+
+    - geopotential_height_wrt_surface_at_interface
+    - lagrangian_vertical_coordinate
+    - ccpp_constituent_properties
+    - ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one
+    - composition_dependent_gas_constant_of_dry_air
+    - ccpp_constituents
+    - number_of_ccpp_constituents
+
+--------------------------
+
+/glade/work/nusbaume/SE_projects/NCAR_atmospheric_physics_fork/utilities/state_converters.meta
+
+    - density_of_dry_air
+    - cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+    - rain_mixing_ratio_wrt_dry_air
+    - rain_mixing_ratio_wrt_moist_air_and_condensed_water
+    - composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+    - composition_dependent_gas_constant_of_dry_air
+
+#######################

--- a/held_suarez/held_suarez_1994.F90
+++ b/held_suarez/held_suarez_1994.F90
@@ -38,11 +38,7 @@ module held_suarez_1994
   !!
   !! Model constants, reset in init call
   !!
-  real(kind_phys)              :: cappa = 2.0_kind_phys / 7.0_kind_phys  ! R/Cp
-  real(kind_phys)              :: cpair = 1004.0_kind_phys        ! specific heat of dry air (J/K/kg)
-  real(kind_phys)              :: psurf_ref = 0.0_kind_phys       ! Surface pressure
-  ! pref_mid_norm are layer midpoints normalized by surface pressure ('eta' coordinate)
-  real(kind_phys), allocatable :: pref_mid_norm(:)
+  real(kind_phys)            :: pref    = 0.0_kind_phys  ! Surface pressure
 
 
 
@@ -52,27 +48,16 @@ contains
 
 !> \section arg_table_held_suarez_1994_init Argument Table
 !! \htmlinclude held_suarez_1994_init.html
-  subroutine held_suarez_1994_init(pver_in, cappa_in, cpair_in, psurf_ref_in, pref_mid_norm_in, errmsg, errflg)
+  subroutine held_suarez_1994_init(pref_in, errmsg, errflg)
     !! Dummy arguments
-    integer,           intent(in) :: pver_in
-    real(kind_phys),   intent(in) :: cappa_in
-    real(kind_phys),   intent(in) :: cpair_in
-    real(kind_phys),   intent(in) :: psurf_ref_in
     real(kind_phys),   intent(in) :: pref_mid_norm_in(:)
     character(len=512),intent(out):: errmsg
     integer,           intent(out):: errflg
 
-    integer               :: pver                     ! Num vertical levels
-
     errmsg = ' '
     errflg = 0
 
-    pver = pver_in
-    allocate(pref_mid_norm(pver))
-    cappa         = cappa_in
-    cpair         = cpair_in
-    psurf_ref     = psurf_ref_in
-    pref_mid_norm = pref_mid_norm_in
+    pref   = pref_in
 
   end subroutine held_suarez_1994_init
 
@@ -84,13 +69,14 @@ contains
     !
     ! Input arguments
     !
-    integer,  intent(in)  :: pver      ! Num vertical levels
-    integer,  intent(in)  :: ncol      ! Num active columns
-    real(kind_phys), intent(in)  :: clat(:)   ! latitudes(radians) for columns
-    real(kind_phys), intent(in)  :: pmid(:,:) ! mid-point pressure
-    real(kind_phys), intent(in)  :: u(:,:)    ! Zonal wind (m/s)
-    real(kind_phys), intent(in)  :: v(:,:)    ! Meridional wind (m/s)
-    real(kind_phys), intent(in)  :: t(:,:)    ! Temperature (K)
+    integer,  intent(in)  :: pver                    ! Num vertical levels
+    integer,  intent(in)  :: ncol                    ! Num active columns
+    real(kind_phys), intent(in)  :: pref_mid_norm(:) ! reference pressure normalized by surface pressure
+    real(kind_phys), intent(in)  :: clat(:)          ! latitudes(radians) for columns
+    real(kind_phys), intent(in)  :: pmid(:,:)        ! mid-point pressure
+    real(kind_phys), intent(in)  :: u(:,:)           ! Zonal wind (m/s)
+    real(kind_phys), intent(in)  :: v(:,:)           ! Meridional wind (m/s)
+    real(kind_phys), intent(in)  :: t(:,:)           ! Temperature (K)
     !
     ! Output arguments
     !

--- a/held_suarez/held_suarez_1994.F90
+++ b/held_suarez/held_suarez_1994.F90
@@ -49,10 +49,12 @@ contains
 !> \section arg_table_held_suarez_1994_init Argument Table
 !! \htmlinclude held_suarez_1994_init.html
   subroutine held_suarez_1994_init(pref_in, errmsg, errflg)
+
     !! Dummy arguments
-    real(kind_phys),   intent(in) :: pref_mid_norm_in(:)
-    character(len=512),intent(out):: errmsg
-    integer,           intent(out):: errflg
+    real(kind_phys),    intent(in)  :: pref_in
+
+    character(len=512), intent(out) :: errmsg
+    integer,            intent(out) :: errflg
 
     errmsg = ' '
     errflg = 0
@@ -63,8 +65,8 @@ contains
 
 !> \section arg_table_held_suarez_1994_run Argument Table
 !! \htmlinclude held_suarez_1994_run.html
-  subroutine held_suarez_1994_run(pver, ncol, pref_mid_norm, clat, &
-       cappa, cpair, pmid, u, v, t, du, dv, s, scheme_name, errmsg, errflg)
+  subroutine held_suarez_1994_run(pver, ncol, pref_mid_norm, clat, cappa, &
+       cpair, pmid, uwnd, vwnd, temp, du, dv, ds, scheme_name, errmsg, errflg)
 
     !
     ! Input arguments
@@ -76,15 +78,15 @@ contains
     real(kind_phys), intent(in)  :: cappa(:,:)       ! ratio of dry air gas constant to specific heat at constant pressure
     real(kind_phys), intent(in)  :: cpair(:,:)       ! specific heat of dry air at constant pressure
     real(kind_phys), intent(in)  :: pmid(:,:)        ! mid-point pressure
-    real(kind_phys), intent(in)  :: u(:,:)           ! Zonal wind (m/s)
-    real(kind_phys), intent(in)  :: v(:,:)           ! Meridional wind (m/s)
-    real(kind_phys), intent(in)  :: t(:,:)           ! Temperature (K)
+    real(kind_phys), intent(in)  :: uwnd(:,:)        ! Zonal wind (m/s)
+    real(kind_phys), intent(in)  :: vwnd(:,:)        ! Meridional wind (m/s)
+    real(kind_phys), intent(in)  :: temp(:,:)        ! Temperature (K)
     !
     ! Output arguments
     !
     real(kind_phys),   intent(out) :: du(:,:)   ! Zonal wind tend
     real(kind_phys),   intent(out) :: dv(:,:)   ! Meridional wind tend
-    real(kind_phys),   intent(out) :: s(:,:)    ! Heating rate
+    real(kind_phys),   intent(out) :: ds(:,:)   ! Heating rate
     character(len=64), intent(out) :: scheme_name
     character(len=512),intent(out):: errmsg
     integer,           intent(out):: errflg
@@ -134,18 +136,18 @@ contains
     do k = 1, pver
       if (pref_mid_norm(k) > sigmab) then
         do i = 1, ncol
-          kt = ka + (ks - ka)*cossqsq(i)*(pref_mid_norm(k) - sigmab)/onemsig
+          kt      = ka + (ks - ka)*cossqsq(i)*(pref_mid_norm(k) - sigmab)/onemsig
           trefc   = 315._kind_phys - (60._kind_phys * sinsq(i))
-          trefa = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/pref)))*(pmid(i,k)/pref)**cappa(i,k)
-          trefa    = max(t00,trefa)
-          s(i,k) = (trefa - t(i,k))*kt*cpair(i,k)
+          trefa   = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/pref)))*(pmid(i,k)/pref)**cappa(i,k)
+          trefa   = max(t00,trefa)
+          ds(i,k) = (trefa - temp(i,k))*kt*cpair(i,k)
         end do
       else
         do i = 1, ncol
           trefc   = 315._kind_phys - 60._kind_phys*sinsq(i)
-          trefa = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/pref)))*(pmid(i,k)/pref)**cappa(i,k)
-          trefa    = max(t00,trefa)
-          s(i,k) = (trefa - t(i,k))*ka*cpair(i,k)
+          trefa   = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/pref)))*(pmid(i,k)/pref)**cappa(i,k)
+          trefa   = max(t00,trefa)
+          ds(i,k) = (trefa - temp(i,k))*ka*cpair(i,k)
         end do
       end if
     end do
@@ -160,8 +162,8 @@ contains
       if (pref_mid_norm(k) > sigmab) then
         kv  = kf*(pref_mid_norm(k) - sigmab)/onemsig
         do i = 1, ncol
-          du(i,k) = -kv*u(i,k)
-          dv(i,k) = -kv*v(i,k)
+          du(i,k) = -kv*uwnd(i,k)
+          dv(i,k) = -kv*vwnd(i,k)
         end do
       end if
     end do

--- a/held_suarez/held_suarez_1994.F90
+++ b/held_suarez/held_suarez_1994.F90
@@ -63,8 +63,8 @@ contains
 
 !> \section arg_table_held_suarez_1994_run Argument Table
 !! \htmlinclude held_suarez_1994_run.html
-  subroutine held_suarez_1994_run(pver, ncol, clat, pmid, &
-       u, v, t, du, dv, s, scheme_name, errmsg, errflg)
+  subroutine held_suarez_1994_run(pver, ncol, pref_mid_norm, clat, &
+       cappa, cpair, pmid, u, v, t, du, dv, s, scheme_name, errmsg, errflg)
 
     !
     ! Input arguments
@@ -73,6 +73,8 @@ contains
     integer,  intent(in)  :: ncol                    ! Num active columns
     real(kind_phys), intent(in)  :: pref_mid_norm(:) ! reference pressure normalized by surface pressure
     real(kind_phys), intent(in)  :: clat(:)          ! latitudes(radians) for columns
+    real(kind_phys), intent(in)  :: cappa(:,:)       ! ratio of dry air gas constant to specific heat at constant pressure
+    real(kind_phys), intent(in)  :: cpair(:,:)       ! specific heat of dry air at constant pressure
     real(kind_phys), intent(in)  :: pmid(:,:)        ! mid-point pressure
     real(kind_phys), intent(in)  :: u(:,:)           ! Zonal wind (m/s)
     real(kind_phys), intent(in)  :: v(:,:)           ! Meridional wind (m/s)
@@ -134,16 +136,16 @@ contains
         do i = 1, ncol
           kt = ka + (ks - ka)*cossqsq(i)*(pref_mid_norm(k) - sigmab)/onemsig
           trefc   = 315._kind_phys - (60._kind_phys * sinsq(i))
-          trefa = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/psurf_ref)))*(pmid(i,k)/psurf_ref)**cappa
+          trefa = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/pref)))*(pmid(i,k)/pref)**cappa(i,k)
           trefa    = max(t00,trefa)
-          s(i,k) = (trefa - t(i,k))*kt*cpair
+          s(i,k) = (trefa - t(i,k))*kt*cpair(i,k)
         end do
       else
         do i = 1, ncol
           trefc   = 315._kind_phys - 60._kind_phys*sinsq(i)
-          trefa = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/psurf_ref)))*(pmid(i,k)/psurf_ref)**cappa
+          trefa = (trefc - 10._kind_phys*cossq(i)*log((pmid(i,k)/pref)))*(pmid(i,k)/pref)**cappa(i,k)
           trefa    = max(t00,trefa)
-          s(i,k) = (trefa - t(i,k))*ka*cpair
+          s(i,k) = (trefa - t(i,k))*ka*cpair(i,k)
         end do
       end if
     end do

--- a/held_suarez/held_suarez_1994.meta
+++ b/held_suarez/held_suarez_1994.meta
@@ -71,19 +71,19 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
-[ u ]
+[ uwnd ]
   standard_name = eastward_wind
   units = m s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
-[ v ]
+[ vwnd ]
   standard_name = northward_wind
   units = m s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
-[ t ]
+[ temp ]
   standard_name = air_temperature
   units = K
   type = real | kind = kind_phys
@@ -101,7 +101,7 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = out
-[ s ]
+[ ds ]
   standard_name = heating_rate
   units = J kg-1 s-1
   type = real | kind = kind_phys

--- a/held_suarez/held_suarez_1994.meta
+++ b/held_suarez/held_suarez_1994.meta
@@ -5,35 +5,11 @@
 [ccpp-arg-table]
   name  = held_suarez_1994_init
   type  = scheme
-[ pver_in ]
-  standard_name =  vertical_layer_dimension
-  units = count
-  type = integer
-  dimensions = ()
-  intent = in
-[ cappa_in ]
-  standard_name =  ratio_of_dry_air_to_water_vapor_gas_constants
-  units = 1
-  type = real | kind = kind_phys
-  dimensions = ()
-  intent = in
-[ cpair_in ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
-  units = J kg-1 K-1
-  type = real | kind = kind_phys
-  dimensions = ()
-  intent = in
-[ psurf_ref_in ]
-  standard_name = reference_pressure_at_surface
+[ pref_in ]
+  standard_name = reference_pressure
   units = Pa
   type = real | kind = kind_phys
   dimensions = ()
-  intent = in
-[ pref_mid_norm_in ]
-  standard_name = reference_pressure_normalized_by_surface_pressure
-  units = Pa
-  type = real | kind = kind_phys
-  dimensions = (vertical_layer_dimension)
   intent = in
 [ errmsg ]
   standard_name = ccpp_error_message
@@ -65,6 +41,12 @@
   type = integer
   dimensions = ()
   intent = in
+[ pref_mid_norm ]
+  standard_name = reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
+  units = 1
+  type = real | kind = kind_phys
+  dimensions = (vertical_layer_dimension)
+  intent = in
 [ clat ]
   standard_name = latitude
   units = radians
@@ -78,13 +60,13 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
 [ u ]
-  standard_name = x_wind
+  standard_name = eastward_wind
   units = m s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
 [ v ]
-  standard_name = y_wind
+  standard_name = northward_wind
   units = m s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
@@ -96,13 +78,13 @@
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = in
 [ du ]
-  standard_name = tendency_of_x_wind
+  standard_name = tendency_of_eastward_wind
   units = m s-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
   intent = out
 [ dv ]
-  standard_name = tendency_of_y_wind
+  standard_name = tendency_of_northward_wind
   units = m s-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent,vertical_layer_dimension)
@@ -115,7 +97,7 @@
   intent = out
 [ scheme_name ]
   standard_name = scheme_name
-  units = 1
+  units = none
   type = character | kind = len=64
   dimensions = ()
   intent = out

--- a/held_suarez/held_suarez_1994.meta
+++ b/held_suarez/held_suarez_1994.meta
@@ -56,13 +56,13 @@
 [ cappa ]
   standard_name = composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
   units = 1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ pmid ]

--- a/held_suarez/held_suarez_1994.meta
+++ b/held_suarez/held_suarez_1994.meta
@@ -41,18 +41,6 @@
   type = integer
   dimensions = ()
   intent = in
-[ cappa ]
-  standard_name = composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
-  units = 1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
-  type = real | kind = kind_phys
-  intent = in
-[ cpair ]
-  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
-  units = J kg-1 K-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
-  type = real | kind = kind_phys
-  intent = in
 [ pref_mid_norm ]
   standard_name = reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure
   units = 1
@@ -64,6 +52,18 @@
   units = radians
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent)
+  intent = in
+[ cappa ]
+  standard_name = composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
+  units = 1
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  type = real | kind = kind_phys
+  intent = in
+[ cpair ]
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+  units = J kg-1 K-1
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  type = real | kind = kind_phys
   intent = in
 [ pmid ]
   standard_name = air_pressure

--- a/held_suarez/held_suarez_1994.meta
+++ b/held_suarez/held_suarez_1994.meta
@@ -42,7 +42,7 @@
   dimensions = ()
   intent = in
 [ cappa ]
-  standard_name = composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_at_constant_pressure
+  standard_name = composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure
   units = 1
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   type = real | kind = kind_phys

--- a/held_suarez/held_suarez_1994.meta
+++ b/held_suarez/held_suarez_1994.meta
@@ -30,7 +30,7 @@
   name  = held_suarez_1994_run
   type  = scheme
 [ pver ]
-  standard_name =  vertical_layer_dimension
+  standard_name = vertical_layer_dimension
   units = count
   type = integer
   dimensions = ()
@@ -40,6 +40,18 @@
   units = count
   type = integer
   dimensions = ()
+  intent = in
+[ cappa ]
+  standard_name = composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_at_constant_pressure
+  units = 1
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  type = real | kind = kind_phys
+  intent = in
+[ cpair ]
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+  units = J kg-1 K-1
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  type = real | kind = kind_phys
   intent = in
 [ pref_mid_norm ]
   standard_name = reference_pressure_in_atmosphere_layer_normalized_by_reference_pressure

--- a/kessler/kessler.F90
+++ b/kessler/kessler.F90
@@ -10,22 +10,18 @@ module kessler
    public :: kessler_init ! init routine
 
    ! Private module data (constants set at initialization)
-   real(kind_phys) :: cp    ! heat capacity at constant pressure, J/(kgK)
    real(kind_phys) :: lv    ! latent heat of vaporization, J/kg
-   real(kind_phys) :: psl   ! reference pressure, mb
-   real(kind_phys) :: rair  ! dry air gas constant J/(kgK)
+   real(kind_phys) :: pref   ! reference pressure, hPa
    real(kind_phys) :: rhoqr ! density of fresh liquid water, kg/m^3
 
 CONTAINS
 
    !> \section arg_table_kessler_init  Argument Table
    !! \htmlinclude kessler_init.html
-   subroutine kessler_init(cp_in, lv_in, psl_in, rair_in, rhoqr_in, errmsg, errflg)
+   subroutine kessler_init(lv_in, pref_in, rhoqr_in, errmsg, errflg)
       ! Set physical constants to be consistent with calling model
-      real(kind_phys),    intent(in)  :: cp_in    ! heat capacity at constant pres., J/(kgK)
       real(kind_phys),    intent(in)  :: lv_in    ! latent heat of vaporization, J/kg
-      real(kind_phys),    intent(in)  :: psl_in   ! reference pressure, mb
-      real(kind_phys),    intent(in)  :: rair_in  ! dry air gas constant J/(kgK)
+      real(kind_phys),    intent(in)  :: pref_in  ! reference pressure, Pa
       real(kind_phys),    intent(in)  :: rhoqr_in ! density of fresh liquid water, kg/m^3
 
       character(len=512), intent(out) :: errmsg
@@ -34,10 +30,8 @@ CONTAINS
       errmsg = ''
       errflg = 0
 
-      cp    = cp_in
       lv    = lv_in
-      psl   = psl_in/100._kind_phys
-      rair  = rair_in
+      pref  = pref_in/100._kind_phys
       rhoqr = rhoqr_in
 
    end subroutine kessler_init
@@ -94,8 +88,8 @@ CONTAINS
 
    !> \section arg_table_kessler_run  Argument Table
    !! \htmlinclude kessler_run.html
-   subroutine kessler_run(ncol, nz, dt,  lyr_surf, lyr_toa, rho, z, pk, theta, &
-        qv, qc, qr, precl, relhum, scheme_name, errmsg, errflg)
+   subroutine kessler_run(ncol, nz, dt, lyr_surf, lyr_toa, cpair, rair, rho, z, &
+        pk, theta, qv, qc, qr, precl, relhum, scheme_name, errmsg, errflg)
 
       !------------------------------------------------
       !   Input / output parameters
@@ -105,6 +99,8 @@ CONTAINS
       real(kind_phys),  intent(in)    :: dt         ! Physics time step (s)
       integer,          intent(in)    :: lyr_surf   ! Index of surface layer in the vertical coordinate
       integer,          intent(in)    :: lyr_toa    ! Index of top of the atmosphere in the vertical coordinate
+      real(kind_phys),  intent(in)    :: cpair(:,:) ! Specific_heat_of_dry_air_at_constant_pressure (J/kg/K)
+      real(kind_phys),  intent(in)    :: rair(:,:)  ! Gas constant of dry air (J/kg/K)
       real(kind_phys),  intent(in)    :: rho(:,:)   ! Dry air density (kg/m^3)
       real(kind_phys),  intent(in)    :: z(:,:)     ! Heights of thermo. levels (m)
       real(kind_phys),  intent(in)    :: pk(:,:)    ! Exner function (p/p0)**(R/cp)
@@ -165,19 +161,23 @@ CONTAINS
          lyr_step = 1
       end if
 
+      f2x = 17.27_kind_phys  ! constant for the saturation mixing ratio
+
       !------------------------------------------------
       !   Begin calculation
       !------------------------------------------------
-      f2x   = 17.27_kind_phys                      ! constant for the saturation mixing ratio
-      f5    = 4093._kind_phys * lv / cp            ! constant for the condensation rate
-      xk    = cp/rair                              ! 1/kappa = cp/R
 
       ! Loop through columns
       do col = 1, ncol
          do klev = lyr_surf, lyr_toa, lyr_step
+
+            !Calculate constants:
+            f5  = 4093._kind_phys * lv / cpair(col,klev) ! constant for the condensation rate
+            xk  = cpair(col,klev) / rair(col,klev)       ! 1/kappa = cp/R
+
             r(klev)     = 0.001_kind_phys * rho(col, klev)
             rhalf(klev) = sqrt(rho(col, lyr_surf) / rho(col, klev))
-            pc(klev)    = 3.8_kind_phys / ((pk(col, klev)**xk) * psl)
+            pc(klev)    = 3.8_kind_phys / ((pk(col, klev)**xk) * pref)
             !
             ! if qr is (round-off) negative then the computation of
             ! velqr triggers floating point exception error when running
@@ -260,7 +260,7 @@ CONTAINS
                     max(-prod-qc(col, klev),0._kind_phys),qr(col, klev))
 
                ! Saturation adjustment following Durran and Klemp (1983) Eqs. (A1-A4), also Klemp and Wilhelmson (1978) Eq. (3.10)
-               theta(col, klev)= theta(col, klev) + (lv / (cp * pk(col, klev)) * (max(prod,-qc(col, klev)) - ern))
+               theta(col, klev)= theta(col, klev) + (lv / (cpair(col,klev) * pk(col, klev)) * (max(prod,-qc(col, klev)) - ern))
                qv(col, klev) = max(qv(col, klev) - max(prod, -qc(col, klev)) + ern, 0._kind_phys)
                qc(col, klev) = qc(col, klev) + max(prod, -qc(col, klev))
                qr(col, klev) = max(qr(col, klev) - ern, 0._kind_phys)

--- a/kessler/kessler.F90
+++ b/kessler/kessler.F90
@@ -6,12 +6,12 @@ module kessler
    private
    save
 
-   public :: kessler_run ! Main routine
    public :: kessler_init ! init routine
+   public :: kessler_run  ! main routine
 
    ! Private module data (constants set at initialization)
    real(kind_phys) :: lv    ! latent heat of vaporization, J/kg
-   real(kind_phys) :: pref   ! reference pressure, hPa
+   real(kind_phys) :: pref  ! reference pressure, hPa
    real(kind_phys) :: rhoqr ! density of fresh liquid water, kg/m^3
 
 CONTAINS
@@ -106,9 +106,9 @@ CONTAINS
       real(kind_phys),  intent(in)    :: pk(:,:)    ! Exner function (p/p0)**(R/cp)
 
       real(kind_phys),  intent(inout) :: theta(:,:) ! Potential temperature (K)
-      real(kind_phys),  intent(inout) :: qv(:,:)    ! Water vapor mixing ratio (gm/gm)
-      real(kind_phys),  intent(inout) :: qc(:,:)    ! Cloud water mixing ratio (gm/gm)
-      real(kind_phys),  intent(inout) :: qr(:,:)    ! Rain  water mixing ratio (gm/gm)
+      real(kind_phys),  intent(inout) :: qv(:,:)    ! Water vapor mixing ratio wrt dry air (kg/kg)
+      real(kind_phys),  intent(inout) :: qc(:,:)    ! Cloud water mixing ratio wrt dry air (kg/kg)
+      real(kind_phys),  intent(inout) :: qr(:,:)    ! Rain water mixing ratio wrt dry air (kg/kg)
 
       real(kind_phys),  intent(out)   :: precl(:)   ! Precipitation rate (m_water / s)
 

--- a/kessler/kessler.F90
+++ b/kessler/kessler.F90
@@ -12,9 +12,9 @@ module kessler
    ! Private module data (constants set at initialization)
    real(kind_phys) :: cp    ! heat capacity at constant pressure, J/(kgK)
    real(kind_phys) :: lv    ! latent heat of vaporization, J/kg
-   real(kind_phys) :: psl   ! reference pressure at sea level, mb
+   real(kind_phys) :: psl   ! reference pressure, mb
    real(kind_phys) :: rair  ! dry air gas constant J/(kgK)
-   real(kind_phys) :: rhoqr ! density of liquid water, kg/m^3
+   real(kind_phys) :: rhoqr ! density of fresh liquid water, kg/m^3
 
 CONTAINS
 
@@ -24,9 +24,9 @@ CONTAINS
       ! Set physical constants to be consistent with calling model
       real(kind_phys),    intent(in)  :: cp_in    ! heat capacity at constant pres., J/(kgK)
       real(kind_phys),    intent(in)  :: lv_in    ! latent heat of vaporization, J/kg
-      real(kind_phys),    intent(in)  :: psl_in   ! reference pressure at sea level, mb
+      real(kind_phys),    intent(in)  :: psl_in   ! reference pressure, mb
       real(kind_phys),    intent(in)  :: rair_in  ! dry air gas constant J/(kgK)
-      real(kind_phys),    intent(in)  :: rhoqr_in ! density of liquid water, kg/m^3
+      real(kind_phys),    intent(in)  :: rhoqr_in ! density of fresh liquid water, kg/m^3
 
       character(len=512), intent(out) :: errmsg
       integer,            intent(out) :: errflg

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -90,8 +90,8 @@
   type = integer
   intent = in
 [ rho ]
-  standard_name = dry_air_density
-  long_name = dry air density
+  standard_name = density_of_dry_air
+  long_name = density of dry air
   units = kg m-3
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -19,7 +19,7 @@
   type = real | kind = kind_phys
   intent = in
 [ rhoqr_in ]
-  standard_name = fresh_liquid_water_density_at_0c
+  standard_name = density_of_fresh_liquid_water_at_0c
   long_name = density of fresh liquid water at 0C
   units = kg m-3
   dimensions = ()

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -4,12 +4,6 @@
 [ccpp-arg-table]
   name = kessler_init
   type = scheme
-[ cp_in ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
-  units =  J kg-1 K-1
-  dimensions = ()
-  type = real | kind = kind_phys
-  intent = in
 [ lv_in ]
   standard_name = latent_heat_of_vaporization_of_water_at_0c
   long_name = latent heat of vaporization of water at 0C
@@ -17,16 +11,10 @@
   dimensions = ()
   type = real | kind = kind_phys
   intent = in
-[ psl_in ]
+[ pref_in ]
   standard_name = reference_pressure
   long_name = reference pressure used in definition of Exner function
   units = mb
-  dimensions = ()
-  type = real | kind = kind_phys
-  intent = in
-[ rair_in ]
-  standard_name = composition_dependent_gas_constant_of_dry_air
-  units =  J kg-1 K-1
   dimensions = ()
   type = real | kind = kind_phys
   intent = in
@@ -88,6 +76,18 @@
   units = count
   dimensions = ()
   type = integer
+  intent = in
+[ cpair ]
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+  units = J kg-1 K-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  intent = in
+[ rair ]
+  standard_name = composition_dependent_gas_constant_of_dry_air
+  units = J kg-1 K-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ rho ]
   standard_name = density_of_dry_air

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -120,7 +120,7 @@
 [ qv ]
   standard_name = water_vapor_mixing_ratio_wrt_dry_air
   long_name = mass mixing ratio of water vapor / dry air
-  advected = true
+  advected = True
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
@@ -128,7 +128,7 @@
 [ qc ]
   standard_name = cloud_liquid_water_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of cloud liquid water / dry air
-  advected = true
+  advected = True
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
@@ -136,7 +136,7 @@
 [ qr ]
   standard_name = rain_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
-  advected = true
+  advected = True
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -18,8 +18,8 @@
   type = real | kind = kind_phys
   intent = in
 [ psl_in ]
-  standard_name = us_standard_atmospheric_pressure_at_sea_level
-  long_name = reference pressure at sea level
+  standard_name = reference_pressure
+  long_name = reference pressure used in definition of Exner function
   units = mb
   dimensions = ()
   type = real | kind = kind_phys
@@ -31,8 +31,8 @@
   type = real | kind = kind_phys
   intent = in
 [ rhoqr_in ]
-  standard_name = density_of_liquid_water_at_0c
-  long_name = density of liquid water at 0C
+  standard_name = fresh_liquid_water_density_at_0c
+  long_name = density of fresh liquid water at 0C
   units = kg m-3
   dimensions = ()
   type = real | kind = kind_phys
@@ -46,7 +46,7 @@
   intent = out
 [ errflg ]
   standard_name = ccpp_error_code
-  long_name = Error flag for error handling in CCPP
+  long_name = Error code for error handling in CCPP
   units = 1
   type = integer
   dimensions = ()
@@ -78,13 +78,13 @@
   type = real | kind = kind_phys
   intent = in
 [ lyr_surf ]
-  standard_name = index_of_bottom_vertical_layer
+  standard_name = vertical_index_at_surface_adjacent_layer
   units = count
   dimensions = ()
   type = integer
   intent = in
 [ lyr_toa ]
-  standard_name = index_of_top_vertical_layer
+  standard_name = vertical_index_at_top_adjacent_layer
   units = count
   dimensions = ()
   type = integer
@@ -97,22 +97,22 @@
   type = real | kind = kind_phys
   intent = in
 [ z ]
-  standard_name = geopotential_height
-  long_name = geopotential height
+  standard_name = geopotential_height_wrt_surface
+  long_name = geopotential height w.r.t. local surface
   units = m
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ pk ]
-  standard_name = inverse_exner_function_wrt_surface_pressure
-  long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
-  units = count
+  standard_name = dimensionless_exner_function
+  long_name = exner function
+  units = 1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ theta ]
-  standard_name = potential_temperature
-  long_name = potential temperature
+  standard_name = air_potential_temperature
+  long_name = air potential temperature
   units = K
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
@@ -134,7 +134,7 @@
   type = real | kind = kind_phys
   intent = inout
 [ qr ]
-  standard_name = rain_water_mixing_ratio_wrt_dry_air
+  standard_name = rain_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
   advected = true
   units = kg kg-1
@@ -143,13 +143,14 @@
   intent = inout
 [ precl ]
   standard_name = total_precipitation_rate_at_surface
-  long_name = precipitation
+  long_name = Total precipitation rate at surface
   units = m s-1
   dimensions = (horizontal_loop_extent)
   type = real | kind = kind_phys
   intent = out
 [ relhum ]
   standard_name = relative_humidity
+  long_name = Relative humidity
   units = percent
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -19,7 +19,7 @@
   type = real | kind = kind_phys
   intent = in
 [ rhoqr_in ]
-  standard_name = density_of_fresh_liquid_water_at_0c
+  standard_name = fresh_liquid_water_density_at_0c
   long_name = density of fresh liquid water at 0C
   units = kg m-3
   dimensions = ()

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -25,7 +25,7 @@
   type = real | kind = kind_phys
   intent = in
 [ rair_in ]
-  standard_name = gas_constant_of_dry_air
+  standard_name = composition_dependent_gas_constant_of_dry_air
   units =  J kg-1 K-1
   dimensions = ()
   type = real | kind = kind_phys

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -81,13 +81,13 @@
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rair ]
   standard_name = composition_dependent_gas_constant_of_dry_air
   units = J kg-1 K-1
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rho ]
   standard_name = density_of_dry_air

--- a/kessler/kessler.meta
+++ b/kessler/kessler.meta
@@ -157,7 +157,7 @@
   intent = out
 [ scheme_name ]
   standard_name = scheme_name
-  units = 1
+  units = none
   type = character | kind = len=64
   dimensions = ()
   intent = out

--- a/kessler/kessler_update.F90
+++ b/kessler/kessler_update.F90
@@ -54,22 +54,23 @@ CONTAINS
 
    !> \section arg_table_kessler_update_run  Argument Table
    !! \htmlinclude kessler_update_run.html
-   subroutine kessler_update_run(nz, ncol, temp, theta, exner, dt,      &
+   subroutine kessler_update_run(nz, ncol, dt, theta, exner,                  &
         temp_prev, ttend_t, errmsg, errflg)
 
       integer,            intent(in)    :: nz
       integer,            intent(in)    :: ncol
-      real(kind_phys),    intent(in)    :: temp(:,:) ! temperature
-      real(kind_phys),    intent(in)    :: exner(:,:)
-      real(kind_phys),    intent(in)    :: dt
+      real(kind_phys),    intent(in)    :: dt             !time step
+      real(kind_phys),    intent(in)    :: theta(:,:)     !potential temperature
+      real(kind_phys),    intent(in)    :: exner(:,:)     !Exner function
+      real(kind_phys),    intent(in)    :: temp_prev(:,:) !air temperature before kessler physics
 
-      real(kind_phys),    intent(inout) :: theta(:,:)
-      real(kind_phys),    intent(inout) :: temp_prev(:,:)
-      real(kind_phys),    intent(inout) :: ttend_t(:,:)
+      real(kind_phys),    intent(inout) :: ttend_t(:,:)   !total air temperature tendency due to
+                                                          !kessler physics
 
       character(len=512), intent(out)   :: errmsg
       integer,            intent(out)   :: errflg
 
+      !Local variables
       integer                           :: klev
       real(kind_phys)                   :: new_temp(ncol)
 

--- a/kessler/kessler_update.F90
+++ b/kessler/kessler_update.F90
@@ -12,15 +12,13 @@ module kessler_update
 
    ! Private module variables
    real(kind_phys)    :: gravit
-   real(kind_phys)    :: cpair
 
 CONTAINS
 
    !> \section arg_table_kessler_update_init  Argument Table
    !! \htmlinclude kessler_update_init.html
-   subroutine kessler_update_init(gravit_in, cpair_in, errmsg, errflg)
+   subroutine kessler_update_init(gravit_in, errmsg, errflg)
       real(kind_phys),    intent(in)  :: gravit_in
-      real(kind_phys),    intent(in)  :: cpair_in
       character(len=512), intent(out) :: errmsg
       integer,            intent(out) :: errflg
 
@@ -28,7 +26,6 @@ CONTAINS
       errflg = 0
 
       gravit = gravit_in
-      cpair = cpair_in
 
    end subroutine kessler_update_init
 
@@ -87,12 +84,13 @@ CONTAINS
 
    !> \section arg_table_kessler_update_timestep_final  Argument Table
    !! \htmlinclude kessler_update_timestep_final.html
-   subroutine kessler_update_timestep_final(nz, temp, zm, phis, st_energy,    &
+   subroutine kessler_update_timestep_final(nz, cpair, temp, zm, phis, st_energy, &
         errflg, errmsg)
 
       ! Dummy arguments
       integer,            intent(in)    :: nz
-      real(kind_phys),    intent(in)    :: temp(:,:) ! temperature
+      real(kind_phys),    intent(in)    :: cpair(:,:) ! Specific_heat_of_dry_air_at_constant_pressure (J/kg/K)
+      real(kind_phys),    intent(in)    :: temp(:,:)  ! Temperature
       real(kind_phys),    intent(in)    :: zm(:,:)
       real(kind_phys),    intent(in)    :: phis(:)
       real(kind_phys),    intent(out)   :: st_energy(:,:)
@@ -107,7 +105,7 @@ CONTAINS
       errflg = 0
 
       do klev = 1, nz
-         st_energy(:,klev) = (temp(:,klev) * cpair) + (gravit * zm(:,klev)) + &
+         st_energy(:,klev) = (temp(:,klev) * cpair(:,klev)) + (gravit * zm(:,klev)) + &
               phis(:)
       end do
 

--- a/kessler/kessler_update.meta
+++ b/kessler/kessler_update.meta
@@ -10,12 +10,6 @@
   dimensions = ()
   type = real | kind = kind_phys
   intent = in
-[ cpair_in ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
-  units = J kg-1 K-1
-  dimensions = ()
-  type = real | kind = kind_phys
-  intent = in
 [ errmsg ]
   standard_name = ccpp_error_message
   long_name = Error message for error handling in CCPP
@@ -141,6 +135,12 @@
   units = count
   dimensions = ()
   type = integer
+  intent = in
+[ cpairv ]
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
+  units = J kg-1 K-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ temp ]
   standard_name = air_temperature

--- a/kessler/kessler_update.meta
+++ b/kessler/kessler_update.meta
@@ -85,28 +85,6 @@
   dimensions = ()
   type = integer
   intent = in
-[ temp ]
-  standard_name = air_temperature
-  state_variable = true
-  type = real | kind = kind_phys
-  units = K
-  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
-  intent = in
-[ theta ]
-  standard_name = potential_temperature
-  long_name = potential temperature
-  units = K
-  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
-  type = real | kind = kind_phys
-  intent = inout
-[ exner ]
-  standard_name = inverse_exner_function_wrt_surface_pressure
-  long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
-  state_variable = true
-  units = count
-  type = real | kind = kind_phys
-  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
-  intent = in
 [ dt ]
   standard_name = timestep_for_physics
   long_name = time step
@@ -114,12 +92,27 @@
   dimensions = ()
   type = real | kind = kind_phys
   intent = in
+[ theta ]
+  standard_name = air_potential_temperature
+  long_name = air potential temperature
+  units = K
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  type = real | kind = kind_phys
+  intent = in
+[ exner ]
+  standard_name = dimensionless_exner_function
+  long_name = exner function
+  state_variable = true
+  units = count
+  type = real | kind = kind_phys
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
 [ temp_prev ]
   standard_name = air_temperature_on_previous_timestep
   units = K
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
-  intent = inout
+  intent = in
 [ ttend_t ]
   standard_name = tendency_of_air_temperature_due_to_model_physics
   type = real | kind = kind_phys
@@ -159,14 +152,15 @@
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ zm ]
-  standard_name = geopotential_height
+  standard_name = geopotential_height_wrt_surface
+  long_name = geopotential height w.r.t. local surface
   state_variable = true
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ phis ]
-  standard_name = geopotential_at_surface
+  standard_name = surface_geopotential
   state_variable = true
   type = real | kind = kind_phys
   units = m2 s-2

--- a/kessler/kessler_update.meta
+++ b/kessler/kessler_update.meta
@@ -36,7 +36,6 @@
   type = scheme
 [ temp ]
   standard_name = air_temperature
-  state_variable = true
   type = real | kind = kind_phys
   units = K
   dimensions = (horizontal_dimension, vertical_layer_dimension)
@@ -102,7 +101,6 @@
 [ exner ]
   standard_name = dimensionless_exner_function
   long_name = exner function
-  state_variable = true
   units = count
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -146,7 +144,6 @@
   intent = in
 [ temp ]
   standard_name = air_temperature
-  state_variable = true
   type = real | kind = kind_phys
   units = K
   dimensions = (horizontal_dimension, vertical_layer_dimension)
@@ -154,14 +151,12 @@
 [ zm ]
   standard_name = geopotential_height_wrt_surface
   long_name = geopotential height w.r.t. local surface
-  state_variable = true
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ phis ]
   standard_name = surface_geopotential
-  state_variable = true
   type = real | kind = kind_phys
   units = m2 s-2
   dimensions = (horizontal_dimension)
@@ -169,7 +164,6 @@
 [ st_energy ]
   standard_name = dry_static_energy
   long_name = Dry static energy
-  state_variable = true
   type = real | kind = kind_phys
   units = J m-2
   dimensions = (horizontal_dimension, vertical_layer_dimension)

--- a/kessler/kessler_update.meta
+++ b/kessler/kessler_update.meta
@@ -101,7 +101,7 @@
 [ exner ]
   standard_name = dimensionless_exner_function
   long_name = exner function
-  units = count
+  units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in

--- a/kessler/kessler_update.meta
+++ b/kessler/kessler_update.meta
@@ -136,7 +136,7 @@
   dimensions = ()
   type = integer
   intent = in
-[ cpairv ]
+[ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
   type = real | kind = kind_phys

--- a/suite_held_suarez_1994.xml
+++ b/suite_held_suarez_1994.xml
@@ -7,5 +7,6 @@
     <scheme>apply_tendency_of_y_wind</scheme>
     <scheme>apply_heating_rate</scheme>
     <scheme>qneg</scheme>
+    <scheme>geopotential_temp</scheme>
   </group>
 </suite>

--- a/suite_held_suarez_1994.xml
+++ b/suite_held_suarez_1994.xml
@@ -6,7 +6,6 @@
     <scheme>apply_tendency_of_eastward_wind</scheme>
     <scheme>apply_tendency_of_northward_wind</scheme>
     <scheme>apply_heating_rate</scheme>
-    <scheme>qneg</scheme>
     <scheme>geopotential_temp</scheme>
   </group>
 </suite>

--- a/suite_held_suarez_1994.xml
+++ b/suite_held_suarez_1994.xml
@@ -3,8 +3,8 @@
 <suite name="held_suarez_1994" version="1.0">
   <group name="physics">
     <scheme>held_suarez_1994</scheme>
-    <scheme>apply_tendency_of_x_wind</scheme>
-    <scheme>apply_tendency_of_y_wind</scheme>
+    <scheme>apply_tendency_of_eastward_wind</scheme>
+    <scheme>apply_tendency_of_northward_wind</scheme>
     <scheme>apply_heating_rate</scheme>
     <scheme>qneg</scheme>
     <scheme>geopotential_temp</scheme>

--- a/suite_kessler.xml
+++ b/suite_kessler.xml
@@ -4,7 +4,7 @@
   <group name="physics">
     <scheme>calc_exner</scheme>
     <scheme>temp_to_potential_temp</scheme>
-    <scheme>calc_dry_ideal_gas_density</scheme>
+    <scheme>calc_dry_air_ideal_gas_density</scheme>
     <scheme>wet_to_dry_water_vapor</scheme>
     <scheme>wet_to_dry_cloud_liquid_water</scheme>
     <scheme>wet_to_dry_rain</scheme>

--- a/suite_kessler.xml
+++ b/suite_kessler.xml
@@ -14,7 +14,7 @@
     <scheme>dry_to_wet_cloud_liquid_water</scheme>
     <scheme>dry_to_wet_rain</scheme>
     <scheme>kessler_update</scheme>
-    <scheme>geopotential_temp</scheme>
     <scheme>qneg</scheme>
+    <scheme>geopotential_temp</scheme>
   </group>
 </suite>

--- a/suite_kessler.xml
+++ b/suite_kessler.xml
@@ -4,7 +4,7 @@
   <group name="physics">
     <scheme>calc_exner</scheme>
     <scheme>temp_to_potential_temp</scheme>
-    <scheme>pres_to_density_dry</scheme>
+    <scheme>calc_dry_ideal_gas_density</scheme>
     <scheme>wet_to_dry_water_vapor</scheme>
     <scheme>wet_to_dry_cloud_liquid_water</scheme>
     <scheme>wet_to_dry_rain</scheme>

--- a/suite_kessler.xml
+++ b/suite_kessler.xml
@@ -14,7 +14,7 @@
     <scheme>dry_to_wet_cloud_liquid_water</scheme>
     <scheme>dry_to_wet_rain</scheme>
     <scheme>kessler_update</scheme>
-    <scheme>geopotential_t</scheme>
+    <scheme>geopotential_temp</scheme>
     <scheme>qneg</scheme>
   </group>
 </suite>

--- a/utilities/geopotential_t.F90
+++ b/utilities/geopotential_t.F90
@@ -140,7 +140,7 @@ CONTAINS
             do klyr = layer_surf, layer_toa, lyr_step
                do icol = 1, ncol
                   !Add thermodynamically active species to mixing ratio factor:
-                  qfac(icol, k)lyr = qfac(icol, klyr) - carr(icol, klyr, cidx)
+                  qfac(icol, klyr) = qfac(icol, klyr) - carr(icol, klyr, cidx)
                end do
             end do
          end if
@@ -177,7 +177,7 @@ CONTAINS
             do icol = 1, ncol
                hkl(icol) = piln(icol, kint-int_step) - piln(icol,kint)
                hkk(icol) = 1._kind_phys -                                     &
-                    (pint(icol,kint) * hkl(icol) * rpdel(icol,klyr))
+                    (pint(icol,kint) * hkl(icol) * rpdel(icol,kyr))
             end do
          else
             do icol = 1,ncol
@@ -189,8 +189,9 @@ CONTAINS
          ! Now compute tv, zm, zi
 
          do icol = 1, ncol
-            tvfac   = (1._kind_phys + (zvir(i,k) + 1._kind_phys) * q(i,k,1) * &
-                      qv(i,k)) * sum_dry_mixing_ratio(i,k)
+            tvfac   = (1._kind_phys + (zvir(icol,klyr) + 1._kind_phys) *      &
+                      qv(icol,klyr)*qfac(icol,klyr)) *                        &
+                      sum_dry_mixing_ratio(icol,klyr)
             tv      = temp(icol,klyr) * tvfac
 
             zm(icol,klyr) = zi(icol,kint-int_step) +                          &

--- a/utilities/geopotential_t.F90
+++ b/utilities/geopotential_t.F90
@@ -12,7 +12,8 @@ module geopotential_t
    ! Author: B.Boville, Feb 2001 from earlier code by Boville and S.J. Lin
    !---------------------------------------------------------------------------
 
-   use ccpp_kinds, only: kind_phys
+   use ccpp_kinds,                only: kind_phys
+   use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 
    implicit none
    private
@@ -26,8 +27,9 @@ CONTAINS
    !> \section arg_table_geopotential_t_run  Argument Table
    !! \htmlinclude geopotential_t_run.html
    subroutine geopotential_t_run(pver, lagrang, layer_surf, layer_toa,        &
-        interface_surf, interface_toa, piln, pint, pmid, pdel, rpdel,         &
-        temp, qv, rair, gravit, zvir, zi, zm, ncol, errflg, errmsg)
+        interface_surf, interface_toa, ncnst, piln, pint, pmid, pdel, rpdel,  &
+        temp, qv, carr, cprops, rair, gravit, zvir, zi, zm, ncol,             &
+        errflg, errmsg)
 
       !-----------------------------------------------------------------------
       !
@@ -47,50 +49,59 @@ CONTAINS
       integer,         intent(in)  :: layer_toa
       integer,         intent(in)  :: interface_surf
       integer,         intent(in)  :: interface_toa
-      integer,         intent(in)  :: ncol       ! Number of longitudes
+      integer,         intent(in)  :: ncnst       ! Number of constituents
+      integer,         intent(in)  :: ncol        ! Number of columns
 
       ! piln: Log interface pressures
-      real(kind_phys), intent(in)  :: piln(:,:)  ! (ncol,pverp)
+      real(kind_phys), intent(in)                   :: piln(:,:)   ! (ncol,pverp)
       ! pint: Interface pressures
-      real(kind_phys), intent(in)  :: pint(:,:)  ! (ncol,pverp)
+      real(kind_phys), intent(in)                   :: pint(:,:)   ! (ncol,pverp)
       ! pmid: Midpoint pressures
-      real(kind_phys), intent(in)  :: pmid(:,:)  ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: pmid(:,:)   ! (ncol,pver)
       ! pdel: layer thickness
-      real(kind_phys), intent(in)  :: pdel(:,:)  ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: pdel(:,:)   ! (ncol,pver)
       ! rpdel: inverse of layer thickness
-      real(kind_phys), intent(in)  :: rpdel(:,:) ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: rpdel(:,:)  ! (ncol,pver)
       ! temp: temperature
-      real(kind_phys), intent(in)  :: temp(:,:)  ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: temp(:,:)   ! (ncol,pver)
       ! qv: specific humidity
-      real(kind_phys), intent(in)  :: qv(:,:)    ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: qv(:,:)     ! (ncol,pver)
+      ! carr: ccpp constituents
+      real(kind_phys), intent(in)                   :: carr(:,:,:) ! (ncol, pver, num_const)
+      ! cprops: ccpp constituent properties
+      type(ccpp_constituent_prop_ptr_t), intent(in) :: cprops(:) ! (num_const)
       ! rair: Gas constant for dry air
-      real(kind_phys), intent(in)  :: rair(:,:)  ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: rair(:,:)   ! (ncol,pver)
       ! gravit: Acceleration of gravity
-      real(kind_phys), intent(in)  :: gravit
+      real(kind_phys), intent(in)                   :: gravit
       ! zvir: rh2o/rair - 1
-      real(kind_phys), intent(in)  :: zvir(:,:)  ! (ncol,pver)
+      real(kind_phys), intent(in)                   :: zvir(:,:)  ! (ncol,pver)
 
       ! Output arguments
 
       ! zi: Height above surface at interfaces
-      real(kind_phys), intent(out) :: zi(:,:)    ! (ncol,pverp)
+      real(kind_phys), intent(out)    :: zi(:,:)    ! (ncol,pverp)
       ! zm: Geopotential height at mid level
-      real(kind_phys), intent(out) :: zm(:,:)    ! (ncol,pver)
+      real(kind_phys), intent(out)    :: zm(:,:)    ! (ncol,pver)
       integer,            intent(out) :: errflg
       character(len=512), intent(out) :: errmsg
       !
       !---------------------------Local variables-----------------------------
       !
-      integer                      :: icol     ! Horizontal index
-      integer                      :: klyr      ! Vertical layer index
-      integer                      :: kint      ! Vertical interface index
-      integer                      :: lyr_step  ! increment to move up a level
-      integer                      :: int_step  ! increment to move up a level
-      real(kind_phys)              :: hkk(ncol) ! diagonal element of hydrostatic matrix
-      real(kind_phys)              :: hkl(ncol) ! off-diagonal element
-      real(kind_phys)              :: rog(ncol,pver) ! Rair / gravit
-      real(kind_phys)              :: tv        ! virtual temperature
-      real(kind_phys)              :: tvfac     ! Tv / T
+      logical                      :: active_flag     ! Flag for whether consitutent is thermodynamically active
+      integer                      :: icol            ! Horizontal index
+      integer                      :: klyr            ! Vertical layer index
+      integer                      :: kint            ! Vertical interface index
+      integer                      :: cidx            ! CCPP constituent index
+      integer                      :: lyr_step        ! increment to move up a level
+      integer                      :: int_step        ! increment to move up a level
+      real(kind_phys)              :: hkk(ncol)       ! diagonal element of hydrostatic matrix
+      real(kind_phys)              :: hkl(ncol)       ! off-diagonal element
+      real(kind_phys)              :: rog(ncol,pver)  ! Rair / gravit
+      real(kind_phys)              :: tv              ! virtual temperature
+      real(kind_phys)              :: tvfac           ! Tv / T
+      real(kind_phys)              :: qfac(ncol,pver) ! factor to convert from wet to dry mixing ratio
+      real(kind_phys)              :: sum_dry_mixing_ratio(ncol,pver) ! sum of dry water mixing ratios
       !
       !-----------------------------------------------------------------------
       !
@@ -100,6 +111,7 @@ CONTAINS
 
       rog(:ncol,:) = rair(:ncol,:) / gravit
 
+      ! Determine order of vertical dimension loop
       if (layer_surf > layer_toa) then
          lyr_step = -1
       else
@@ -113,6 +125,46 @@ CONTAINS
 
       ! The surface height is zero by definition.
       zi(:ncol, interface_surf) = 0.0_kind_phys
+
+      ! For the computation of generalized virtual temperature (equation 16
+      ! in Lauritzen et al. (2018);  https://doi.org/10.1029/2017MS001257)
+      !
+      ! Compute factor for converting wet to dry mixing ratio (eq.7)
+      !
+      qfac = 1._kind_phys
+      active_flag = .false.
+      do cidx = 1,ncnst
+         !Check if constituent is thermodynamically active:
+         call cprops(cidx)%is_thermo_active(active_flag)
+         if (active_flag)
+            do klyr = layer_surf, layer_toa, lyr_step
+               do icol = 1, ncol
+                  !Add thermodynamically active species to mixing ratio factor:
+                  qfac(icol, k)lyr = qfac(icol, klyr) - carr(icol, klyr, cidx)
+               end do
+            end do
+         end if
+      end do
+      qfac = 1._kind_phys/qfac
+
+      ! Compute sum of thermodynamically active constituent
+      ! mixing ratios with respect to dry air:
+      sum_dry_mixing_ratio = 1._kind_phys
+      active_flag = .false.
+      do cidx = 1,ncnst
+         !Check if constituent is thermodynamically active:
+         call cprops(cidx)%is_thermo_active(active_flag)
+         if (active_flag)
+            do klyr = layer_surf, layer_toa, lyr_step
+               do icol = 1, ncol
+                  sum_dry_mixing_ratio(icol, klyr) =                          &
+                  sum_dry_mixing_ratio(icol, klyr) +                          &
+                  carr(icol, klyr, cidx) * qfac(icol,klyr)
+               end do
+            end do
+         end if
+      end do
+      sum_dry_mixing_ratio(:,:) = 1._kind_phys/sum_dry_mixing_ratio(:,:)
 
       ! Compute zi, zm from bottom up.
       ! Note, zi(i,k) is the interface above zm(i,k) when ordered top to bot
@@ -137,7 +189,8 @@ CONTAINS
          ! Now compute tv, zm, zi
 
          do icol = 1, ncol
-            tvfac   = 1._kind_phys + zvir(icol,klyr) * qv(icol,klyr)
+            tvfac   = (1._kind_phys + (zvir(i,k) + 1._kind_phys) * q(i,k,1) * &
+                      qv(i,k)) * sum_dry_mixing_ratio(i,k)
             tv      = temp(icol,klyr) * tvfac
 
             zm(icol,klyr) = zi(icol,kint-int_step) +                          &

--- a/utilities/geopotential_t.F90
+++ b/utilities/geopotential_t.F90
@@ -27,7 +27,7 @@ CONTAINS
    !! \htmlinclude geopotential_t_run.html
    subroutine geopotential_t_run(pver, lagrang, layer_surf, layer_toa,        &
         interface_surf, interface_toa, piln, pint, pmid, pdel, rpdel,         &
-        t, q, rair, gravit, zvir, zi, zm, ncol, errflg, errmsg)
+        temp, qv, rair, gravit, zvir, zi, zm, ncol, errflg, errmsg)
 
       !-----------------------------------------------------------------------
       !
@@ -59,10 +59,10 @@ CONTAINS
       real(kind_phys), intent(in)  :: pdel(:,:)  ! (ncol,pver)
       ! rpdel: inverse of layer thickness
       real(kind_phys), intent(in)  :: rpdel(:,:) ! (ncol,pver)
-      ! t: temperature
-      real(kind_phys), intent(in)  :: t(:,:)     ! (ncol,pver)
-      ! q: specific humidity
-      real(kind_phys), intent(in)  :: q(:,:)     ! (ncol,pver)
+      ! temp: temperature
+      real(kind_phys), intent(in)  :: temp(:,:)  ! (ncol,pver)
+      ! qv: specific humidity
+      real(kind_phys), intent(in)  :: qv(:,:)    ! (ncol,pver)
       ! rair: Gas constant for dry air
       real(kind_phys), intent(in)  :: rair(:,:)  ! (ncol,pver)
       ! gravit: Acceleration of gravity
@@ -137,8 +137,8 @@ CONTAINS
          ! Now compute tv, zm, zi
 
          do icol = 1, ncol
-            tvfac   = 1._kind_phys + zvir(icol,klyr) * q(icol,klyr)
-            tv      = t(icol,klyr) * tvfac
+            tvfac   = 1._kind_phys + zvir(icol,klyr) * qv(icol,klyr)
+            tv      = temp(icol,klyr) * tvfac
 
             zm(icol,klyr) = zi(icol,kint-int_step) +                          &
                  (rog(icol,klyr) * tv * hkk(icol))

--- a/utilities/geopotential_t.meta
+++ b/utilities/geopotential_t.meta
@@ -19,32 +19,32 @@
   type = logical
   intent = in
 [ layer_surf ]
-  standard_name = index_of_bottom_vertical_layer
+  standard_name = vertical_index_at_surface_adjacent_layer
   units = count
   dimensions = ()
   type = integer
   intent = in
 [ layer_toa ]
-  standard_name = index_of_top_vertical_layer
+  standard_name = vertical_index_at_top_adjacent_layer
   units = count
   dimensions = ()
   type = integer
   intent = in
 [ interface_surf ]
-  standard_name = index_of_bottom_vertical_interface
+  standard_name = vertical_index_at_surface_interface
   units = count
   dimensions = ()
   type = integer
   intent = in
 [ interface_toa ]
-  standard_name = index_of_top_vertical_interface
+  standard_name = vertical_index_at_top_interface
   units = count
   dimensions = ()
   type = integer
   intent = in
 [ piln ]
-  standard_name = ln_of_air_pressure_at_interface
-  long_name = ln(air_pressure_at_interface)
+  standard_name = ln_air_pressure_at_interface
+  long_name = natural log of air_pressure_at_interface
   type = real | kind = kind_phys
   units = 1
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
@@ -63,25 +63,26 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rpdel ]
-  standard_name = reciprocal_of_pressure_thickness
+  standard_name = reciprocal_of_air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
-[ t ]
+[ temp ]
   standard_name = air_temperature
   type = real | kind = kind_phys
   units = K
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
-[ q ]
-  standard_name = specific_humidity
+[ qv ]
+  standard_name = mixing_ratio_of_vapor_wrt_moist_air
+  long_name = Ratio of the mass of water vapor to the mass of dry air plus water vapor
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -105,13 +106,13 @@
   type = real | kind = kind_phys
   intent = in
 [ zi ]
-  standard_name = geopotential_height_at_interface
+  standard_name = geopotential_height_wrt_surface_at_interface
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
   intent = out
 [ zm ]
-  standard_name = geopotential_height
+  standard_name = geopotential_height_wrt_surface
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/geopotential_t.meta
+++ b/utilities/geopotential_t.meta
@@ -45,14 +45,12 @@
 [ piln ]
   standard_name = ln_of_air_pressure_at_interface
   long_name = ln(air_pressure_at_interface)
-  state_variable = true
   type = real | kind = kind_phys
   units = 1
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
   intent = in
 [ pint ]
   standard_name = air_pressure_at_interface
-  state_variable = true
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
@@ -60,35 +58,30 @@
 [ pmid ]
   standard_name = air_pressure
   long_name = Midpoint air pressure
-  state_variable = true
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdel ]
   standard_name = pressure_thickness
-  state_variable = true
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rpdel ]
   standard_name = reciprocal_of_pressure_thickness
-  state_variable = true
   type = real | kind = kind_phys
   units = Pa-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ t ]
   standard_name = air_temperature
-  state_variable = true
   type = real | kind = kind_phys
   units = K
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ q ]
   standard_name = specific_humidity
-  state_variable = true
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -113,14 +106,12 @@
   intent = in
 [ zi ]
   standard_name = geopotential_height_at_interface
-  state_variable = true
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_loop_extent, vertical_interface_dimension)
   intent = out
 [ zm ]
   standard_name = geopotential_height
-  state_variable = true
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/geopotential_t.meta
+++ b/utilities/geopotential_t.meta
@@ -100,7 +100,7 @@
   type = real | kind = kind_phys
   intent = in
 [ zvir ]
-  standard_name = composition_dependent_ratio_of_water_vapor_to_dry_air_gas_constants_minus_one
+  standard_name = ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one
   units = -1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys

--- a/utilities/geopotential_t.meta
+++ b/utilities/geopotential_t.meta
@@ -42,6 +42,12 @@
   dimensions = ()
   type = integer
   intent = in
+[ ncnst ]
+  standard_name = number_of_ccpp_constituents
+  units = count
+  type = integer
+  dimensions = ()
+  intent = in
 [ piln ]
   standard_name = ln_air_pressure_at_interface
   long_name = natural log of air_pressure_at_interface
@@ -86,6 +92,18 @@
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
+  intent = in
+[ carr ]
+  standard_name = ccpp_constituents
+  units = kg kg-1
+  type = real | kind = kind_phys
+  dimensions = (horizontal_dimension,vertical_layer_dimension,number_of_ccpp_constituents)
+  intent = inout
+[ cprops ]
+  standard_name = ccpp_constituent_properties
+  units = None
+  type = ccpp_constituent_prop_ptr_t
+  dimensions = (number_of_ccpp_constituents)
   intent = in
 [ rair ]
   standard_name = composition_dependent_gas_constant_of_dry_air

--- a/utilities/geopotential_temp.F90
+++ b/utilities/geopotential_temp.F90
@@ -159,7 +159,7 @@ CONTAINS
                do icol = 1, ncol
                   sum_dry_mixing_ratio(icol, klyr) =                          &
                   sum_dry_mixing_ratio(icol, klyr) +                          &
-                  carr(icol, klyr, cidx) * qfac(icol,klyr)
+                       carr(icol, klyr, cidx) * qfac(icol,klyr)
                end do
             end do
          end if

--- a/utilities/geopotential_temp.F90
+++ b/utilities/geopotential_temp.F90
@@ -1,4 +1,4 @@
-module geopotential_t
+module geopotential_temp
 
    !---------------------------------------------------------------------------
    ! Compute geopotential from temperature
@@ -19,14 +19,14 @@ module geopotential_t
    private
    save
 
-   public geopotential_t_run
+   public geopotential_temp_run
 
 CONTAINS
    !===========================================================================
 
    !> \section arg_table_geopotential_t_run  Argument Table
    !! \htmlinclude geopotential_t_run.html
-   subroutine geopotential_t_run(pver, lagrang, layer_surf, layer_toa,        &
+   subroutine geopotential_temp_run(pver, lagrang, layer_surf, layer_toa,        &
         interface_surf, interface_toa, ncnst, piln, pint, pmid, pdel, rpdel,  &
         temp, qv, carr, cprops, rair, gravit, zvir, zi, zm, ncol,             &
         errflg, errmsg)
@@ -136,7 +136,7 @@ CONTAINS
       do cidx = 1,ncnst
          !Check if constituent is thermodynamically active:
          call cprops(cidx)%is_thermo_active(active_flag)
-         if (active_flag)
+         if (active_flag) then
             do klyr = layer_surf, layer_toa, lyr_step
                do icol = 1, ncol
                   !Add thermodynamically active species to mixing ratio factor:
@@ -154,7 +154,7 @@ CONTAINS
       do cidx = 1,ncnst
          !Check if constituent is thermodynamically active:
          call cprops(cidx)%is_thermo_active(active_flag)
-         if (active_flag)
+         if (active_flag) then
             do klyr = layer_surf, layer_toa, lyr_step
                do icol = 1, ncol
                   sum_dry_mixing_ratio(icol, klyr) =                          &
@@ -177,7 +177,7 @@ CONTAINS
             do icol = 1, ncol
                hkl(icol) = piln(icol, kint-int_step) - piln(icol,kint)
                hkk(icol) = 1._kind_phys -                                     &
-                    (pint(icol,kint) * hkl(icol) * rpdel(icol,kyr))
+                    (pint(icol,kint) * hkl(icol) * rpdel(icol,klyr))
             end do
          else
             do icol = 1,ncol
@@ -202,6 +202,6 @@ CONTAINS
          klyr = klyr + lyr_step
       end do
 
-   end subroutine geopotential_t_run
+   end subroutine geopotential_temp_run
 
-end module geopotential_t
+end module geopotential_temp

--- a/utilities/geopotential_temp.F90
+++ b/utilities/geopotential_temp.F90
@@ -24,8 +24,8 @@ module geopotential_temp
 CONTAINS
    !===========================================================================
 
-   !> \section arg_table_geopotential_t_run  Argument Table
-   !! \htmlinclude geopotential_t_run.html
+   !> \section arg_table_geopotential_temp_run  Argument Table
+   !! \htmlinclude geopotential_temp_run.html
    subroutine geopotential_temp_run(pver, lagrang, layer_surf, layer_toa,        &
         interface_surf, interface_toa, ncnst, piln, pint, pmid, pdel, rpdel,  &
         temp, qv, carr, cprops, rair, gravit, zvir, zi, zm, ncol,             &

--- a/utilities/geopotential_temp.meta
+++ b/utilities/geopotential_temp.meta
@@ -120,7 +120,7 @@
   intent = in
 [ zvir ]
   standard_name = ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one
-  units = -1
+  units = 1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in

--- a/utilities/geopotential_temp.meta
+++ b/utilities/geopotential_temp.meta
@@ -89,6 +89,7 @@
 [ qv ]
   standard_name = water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = Ratio of the mass of water vapor to the mass of dry air plus water vapor and condensates
+  advected = True
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/geopotential_temp.meta
+++ b/utilities/geopotential_temp.meta
@@ -98,7 +98,7 @@
   standard_name = ccpp_constituents
   units = kg kg-1
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension,vertical_layer_dimension,number_of_ccpp_constituents)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_ccpp_constituents)
   intent = in
 [ cprops ]
   standard_name = ccpp_constituent_properties

--- a/utilities/geopotential_temp.meta
+++ b/utilities/geopotential_temp.meta
@@ -1,8 +1,8 @@
 [ccpp-table-properties]
-  name = geopotential_t
+  name = geopotential_temp
   type = scheme
 [ccpp-arg-table]
-  name = geopotential_t_run
+  name = geopotential_temp_run
   type = scheme
 [ pver ]
   standard_name = vertical_layer_dimension

--- a/utilities/geopotential_temp.meta
+++ b/utilities/geopotential_temp.meta
@@ -98,7 +98,7 @@
   units = kg kg-1
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension,vertical_layer_dimension,number_of_ccpp_constituents)
-  intent = inout
+  intent = in
 [ cprops ]
   standard_name = ccpp_constituent_properties
   units = None

--- a/utilities/geopotential_temp.meta
+++ b/utilities/geopotential_temp.meta
@@ -87,8 +87,8 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qv ]
-  standard_name = mixing_ratio_of_vapor_wrt_moist_air
-  long_name = Ratio of the mass of water vapor to the mass of dry air plus water vapor
+  standard_name = water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = Ratio of the mass of water vapor to the mass of dry air plus water vapor and condensates
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/physics_tendency_updaters.F90
+++ b/utilities/physics_tendency_updaters.F90
@@ -5,22 +5,22 @@ module physics_tendency_updaters
   implicit none
   private
 
-  public :: apply_tendency_of_x_wind_run
-  public :: apply_tendency_of_y_wind_run
+  public :: apply_tendency_of_eastward_wind_run
+  public :: apply_tendency_of_northward_wind_run
   public :: apply_heating_rate_run
   public :: apply_tendency_of_air_temperature_run
 
 CONTAINS
 
-   !> \section arg_table_apply_tendency_of_x_wind_run  Argument Table
-   !! \htmlinclude apply_tendency_of_x_wind_run.html
-   subroutine apply_tendency_of_x_wind_run(nz, dudt, u, dudt_total, dt,             &
+   !> \section arg_table_apply_tendency_of_eastward_wind_run  Argument Table
+   !! \htmlinclude apply_tendency_of_eastward_wind_run.html
+   subroutine apply_tendency_of_eastward_wind_run(nz, dudt, u, dudt_total, dt,             &
         errcode, errmsg)
       ! Dummy arguments
       integer,            intent(in)    :: nz              ! Num vertical  layers
-      real(kind_phys),    intent(in)    :: dudt(:,:)       ! tendency of x wind
-      real(kind_phys),    intent(inout) :: u(:,:)          ! x wind
-      real(kind_phys),    intent(inout) :: dudt_total(:,:) ! total tendency of x wind
+      real(kind_phys),    intent(in)    :: dudt(:,:)       ! tendency of eastward wind
+      real(kind_phys),    intent(inout) :: u(:,:)          ! eastward wind
+      real(kind_phys),    intent(inout) :: dudt_total(:,:) ! total tendency of eastward wind
       real(kind_phys),    intent(in)    :: dt              ! physics time step
       integer,            intent(out)   :: errcode
       character(len=512), intent(out)   :: errmsg
@@ -36,17 +36,17 @@ CONTAINS
          dudt_total(:, klev) = dudt_total(:, klev) + dudt(:, klev)
       end do
 
-   end subroutine apply_tendency_of_x_wind_run
+   end subroutine apply_tendency_of_eastward_wind_run
 
-   !> \section arg_table_apply_tendency_of_y_wind_run  Argument Table
-   !! \htmlinclude apply_tendency_of_y_wind_run.html
-   subroutine apply_tendency_of_y_wind_run(nz, dvdt, v, dvdt_total, dt,             &
+   !> \section arg_table_apply_tendency_of_northward_wind_run  Argument Table
+   !! \htmlinclude apply_tendency_of_northward_wind_run.html
+   subroutine apply_tendency_of_northward_wind_run(nz, dvdt, v, dvdt_total, dt,             &
         errcode, errmsg)
       ! Dummy arguments
-      integer,            intent(in)    :: nz              ! Num vertical  layers
-      real(kind_phys),    intent(in)    :: dvdt(:,:)       ! tendency of y wind
-      real(kind_phys),    intent(inout) :: v(:,:)          ! y wind
-      real(kind_phys),    intent(inout) :: dvdt_total(:,:) ! total tendency of y wind
+      integer,            intent(in)    :: nz              ! Num vertical layers
+      real(kind_phys),    intent(in)    :: dvdt(:,:)       ! tendency of northward wind
+      real(kind_phys),    intent(inout) :: v(:,:)          ! northward wind
+      real(kind_phys),    intent(inout) :: dvdt_total(:,:) ! total tendency of northward wind
       real(kind_phys),    intent(in)    :: dt              ! physics time step
       integer,            intent(out)   :: errcode
       character(len=512), intent(out)   :: errmsg
@@ -62,7 +62,7 @@ CONTAINS
          dvdt_total(:, klev) = dvdt_total(:, klev) + dvdt(:, klev)
       end do
 
-   end subroutine apply_tendency_of_y_wind_run
+   end subroutine apply_tendency_of_northward_wind_run
 
    !> \section arg_table_apply_heating_rate_run  Argument Table
    !! \htmlinclude apply_heating_rate_run.html

--- a/utilities/physics_tendency_updaters.F90
+++ b/utilities/physics_tendency_updaters.F90
@@ -74,7 +74,7 @@ CONTAINS
       real(kind_phys),    intent(inout) :: temp(:,:)         ! air temperature
       real(kind_phys),    intent(inout) :: dTdt_total(:,:)   ! total temperature tend.
       real(kind_phys),    intent(in)    :: dt                ! physics time step
-      real(kind_phys),    intent(in)    :: cpair             ! specific heat, dry air
+      real(kind_phys),    intent(in)    :: cpair(:,:)        ! specific heat, dry air
       integer,            intent(out)   :: errcode
       character(len=512), intent(out)   :: errmsg
 
@@ -85,7 +85,7 @@ CONTAINS
       errmsg = ''
 
       do klev = 1, nz
-         temp(:, klev) = temp(:, klev) + (heating_rate(:, klev) * dt / cpair)
+         temp(:, klev) = temp(:, klev) + (heating_rate(:, klev) * dt / cpair(:, klev))
          dTdt_total(:, klev) = dTdt_total(:, klev) + (heating_rate(:, klev) / cpair)
       end do
 

--- a/utilities/physics_tendency_updaters.F90
+++ b/utilities/physics_tendency_updaters.F90
@@ -86,7 +86,7 @@ CONTAINS
 
       do klev = 1, nz
          temp(:, klev) = temp(:, klev) + (heating_rate(:, klev) * dt / cpair(:, klev))
-         dTdt_total(:, klev) = dTdt_total(:, klev) + (heating_rate(:, klev) / cpair)
+         dTdt_total(:, klev) = dTdt_total(:, klev) + (heating_rate(:, klev) / cpair(:,klev))
       end do
 
    end subroutine apply_heating_rate_run

--- a/utilities/physics_tendency_updaters.meta
+++ b/utilities/physics_tendency_updaters.meta
@@ -23,7 +23,6 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
-  state_variable = True
 [ dudt_total ]
   standard_name = tendency_of_x_wind_due_to_model_physics
   units = m s-2
@@ -77,7 +76,6 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
-  state_variable = True
 [ dvdt_total ]
   standard_name = tendency_of_y_wind_due_to_model_physics
   units = m s-2
@@ -131,7 +129,6 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
-  state_variable = true
 [ dTdt_total ]
   standard_name = tendency_of_air_temperature_due_to_model_physics
   units = K s-1
@@ -191,7 +188,6 @@
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
-  state_variable = true
 [ dTdt_total ]
   standard_name = tendency_of_air_temperature_due_to_model_physics
   units = K s-1

--- a/utilities/physics_tendency_updaters.meta
+++ b/utilities/physics_tendency_updaters.meta
@@ -145,7 +145,7 @@
 [ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
-  dimensions = ()
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ errcode ]

--- a/utilities/physics_tendency_updaters.meta
+++ b/utilities/physics_tendency_updaters.meta
@@ -1,8 +1,8 @@
 [ccpp-table-properties]
-  name = apply_tendency_of_x_wind
+  name = apply_tendency_of_eastward_wind
   type = scheme
 [ccpp-arg-table]
-  name = apply_tendency_of_x_wind_run
+  name = apply_tendency_of_eastward_wind_run
   type = scheme
 [ nz ]
   standard_name = vertical_layer_dimension
@@ -12,19 +12,19 @@
   dimensions = ()
   intent = in
 [ dudt ]
-  standard_name = tendency_of_x_wind
+  standard_name = tendency_of_eastward_wind
   units = m s-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ u ]
-  standard_name = x_wind
+  standard_name = eastward_wind
   units = m s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
 [ dudt_total ]
-  standard_name = tendency_of_x_wind_due_to_model_physics
+  standard_name = tendency_of_eastward_wind_due_to_model_physics
   units = m s-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -52,10 +52,10 @@
   intent = out
 #####################################################################
 [ccpp-table-properties]
-  name = apply_tendency_of_y_wind
+  name = apply_tendency_of_northward_wind
   type = scheme
 [ccpp-arg-table]
-  name = apply_tendency_of_y_wind_run
+  name = apply_tendency_of_northward_wind_run
   type = scheme
 [ nz ]
   standard_name = vertical_layer_dimension
@@ -65,19 +65,19 @@
   dimensions = ()
   intent = in
 [ dvdt ]
-  standard_name = tendency_of_y_wind
+  standard_name = tendency_of_northward_wind
   units = m s-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ v ]
-  standard_name = y_wind
+  standard_name = northward_wind
   units = m s-1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = inout
 [ dvdt_total ]
-  standard_name = tendency_of_y_wind_due_to_model_physics
+  standard_name = tendency_of_northward_wind_due_to_model_physics
   units = m s-2
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -143,7 +143,7 @@
   type = real | kind = kind_phys
   intent = in
 [ cpair ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
   dimensions = ()
   type = real | kind = kind_phys

--- a/utilities/physics_tendency_updaters.meta
+++ b/utilities/physics_tendency_updaters.meta
@@ -145,7 +145,7 @@
 [ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ errcode ]

--- a/utilities/qneg.F90
+++ b/utilities/qneg.F90
@@ -55,15 +55,13 @@ CONTAINS
 
    !> \section arg_table_qneg_init Argument Table
    !! \htmlinclude qneg_init.html
-   subroutine qneg_init(print_qneg_warn, num_constituents_in, qprops,         &
+   subroutine qneg_init(print_qneg_warn, num_constituents_in,        &
         errcode, errmsg)
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       !use cam_history,    only: addfld, horiz_only
 
       character(len=*),                    intent(in)  :: print_qneg_warn
       integer,                             intent(in)  :: num_constituents_in
-      ! qprops is the array of constituent properties
-      type(ccpp_constituent_prop_ptr_t), intent(in)  :: qprops(:)
       integer,                             intent(out) :: errcode
       character(len=512),                  intent(out) :: errmsg
 
@@ -173,7 +171,7 @@ CONTAINS
    !> \section arg_table_qneg_run Argument Table
    !! \htmlinclude qneg_run.html
    subroutine qneg_run(subnam, num_columns, lver, num_constituents,  &
-        qmin, qprops, q, errcode, errmsg)
+        qmin, q, errcode, errmsg)
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 !!XXgoldyXX: v Reinstate when history is implemented
 #if 0
@@ -204,8 +202,6 @@ CONTAINS
       integer,                           intent(in)    :: num_constituents
       ! qmin: Global minimum constituent concentration
       real(kind_phys),                   intent(in)    :: qmin(:)
-      ! qprops: The array of constituent properties
-      type(ccpp_constituent_prop_ptr_t), intent(in)    :: qprops(:)
       ! q: The array of constituents
       real(kind_phys),                   intent(inout) :: q(:,:,:)
       integer,                           intent(out)   :: errcode

--- a/utilities/qneg.F90
+++ b/utilities/qneg.F90
@@ -3,7 +3,6 @@ module qneg
    !   -- will not be ported back to CAM6 --
 
    use ccpp_kinds,                only: kind_phys
-   use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 !!XXgoldyXX: v Reinstate when history is implemented
 #if 0
    use cam_history_support, only: max_fieldname_len
@@ -57,7 +56,6 @@ CONTAINS
    !! \htmlinclude qneg_init.html
    subroutine qneg_init(print_qneg_warn, num_constituents_in,        &
         errcode, errmsg)
-      use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
       !use cam_history,    only: addfld, horiz_only
 
       character(len=*),                    intent(in)  :: print_qneg_warn
@@ -170,9 +168,7 @@ CONTAINS
 
    !> \section arg_table_qneg_run Argument Table
    !! \htmlinclude qneg_run.html
-   subroutine qneg_run(subnam, num_columns, lver, num_constituents,  &
-        qmin, q, errcode, errmsg)
-      use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
+   subroutine qneg_run(subnam, num_columns, lver, qmin, q, errcode, errmsg)
 !!XXgoldyXX: v Reinstate when history is implemented
 #if 0
       use cam_history, only: outfld
@@ -198,8 +194,6 @@ CONTAINS
       integer,                           intent(in)    :: num_columns
       ! lver: Number of vertical levels in column
       integer,                           intent(in)    :: lver
-      ! num_constituents: Number of constituents
-      integer,                           intent(in)    :: num_constituents
       ! qmin: Global minimum constituent concentration
       real(kind_phys),                   intent(in)    :: qmin(:)
       ! q: The array of constituents
@@ -238,7 +232,7 @@ CONTAINS
          index = -1
       end if
 
-      do m = 1, num_constituent             s
+      do m = 1, num_constituents
          nvals = 0
          found = .false.
          worst = worst_reset
@@ -372,7 +366,8 @@ CONTAINS
             do m = 1, num_constituents
                if ( (global_warn_num(m) > 0) .and.                            &
                     (abs(global_warn_worst(m)) > tol)) then
-                  call qprops(m)%standard_name(cnst_name, ierr, errmsg)
+                  call qprops(m)%standard_name(cnst_name, errcode=ierr,       &
+                                               errmsg=errmsg)
                   write(iulog, 9100) trim(qneg_warn_labels(index)),           &
                        trim(cnst_name), global_warn_num(m),                   &
                        global_warn_worst(m)

--- a/utilities/qneg.F90
+++ b/utilities/qneg.F90
@@ -172,7 +172,7 @@ CONTAINS
 
    !> \section arg_table_qneg_run Argument Table
    !! \htmlinclude qneg_run.html
-   subroutine qneg_run(subnam, loop_begin, loop_end, lver, num_constituents,  &
+   subroutine qneg_run(subnam, num_columns, lver, num_constituents,  &
         qmin, qprops, q, errcode, errmsg)
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 !!XXgoldyXX: v Reinstate when history is implemented
@@ -196,8 +196,8 @@ CONTAINS
       !
       character(len=*), intent(in) :: subnam ! name of calling routine
 
-      integer,                           intent(in)    :: loop_begin
-      integer,                           intent(in)    :: loop_end
+      ! num_columns: Horizontal loop extent
+      integer,                           intent(in)    :: num_columns
       ! lver: Number of vertical levels in column
       integer,                           intent(in)    :: lver
       ! num_constituents: Number of constituents
@@ -221,9 +221,9 @@ CONTAINS
 
       logical  :: found            ! true => at least 1 minimum violator found
 
-      real(kind_phys) :: badvals(loop_begin:loop_end, lver) ! Collector for outfld calls
-      real(kind_phys) :: badcols(loop_begin:loop_end)  ! Column sum for outfld
-      real(kind_phys) :: worst           ! biggest violator
+      real(kind_phys) :: badvals(1:num_columns, lver) ! Collector for outfld calls
+      real(kind_phys) :: badcols(1:num_columns)       ! Column sum for outfld
+      real(kind_phys) :: worst                        ! biggest violator
       !
       !-----------------------------------------------------------------------
       !
@@ -242,7 +242,7 @@ CONTAINS
          index = -1
       end if
 
-      do m = 1, num_constituents
+      do m = 1, num_constituent             s
          nvals = 0
          found = .false.
          worst = worst_reset
@@ -255,7 +255,7 @@ CONTAINS
          !
 
          do k = 1, lver
-            do i = loop_begin, loop_end
+            do i = 1, num_columns
                if (q(i,k,m) < qmin(m)) then
                   found = .true.
                   nvals = nvals + 1
@@ -296,14 +296,13 @@ CONTAINS
    !> \section arg_table_qneg_timestep_final Argument Table
    !! \htmlinclude qneg_timestep_final.html
    subroutine qneg_timestep_final(mpi_communicator, rootprocid, isrootproc,   &
-        iulog, log_output, qprops, errcode, errmsg)
+        iulog, qprops, errcode, errmsg)
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 
       integer,                           intent(in)  :: mpi_communicator
       integer,                           intent(in)  :: rootprocid
       logical,                           intent(in)  :: isrootproc
       integer,                           intent(in)  :: iulog
-      logical,                           intent(in)  :: log_output
       ! qprops: The array of constituent properties
       type(ccpp_constituent_prop_ptr_t), intent(in)  :: qprops(:)
       integer,                           intent(out) :: errcode
@@ -314,21 +313,20 @@ CONTAINS
 
       if (timestep_reset .and. collect_stats) then
          call qneg_print_summary(mpi_communicator, rootprocid, isrootproc,    &
-              iulog, log_output, qprops)
+              iulog, qprops)
       end if
 
    end subroutine qneg_timestep_final
    !> \section arg_table_qneg_final Argument Table
    !! \htmlinclude qneg_final.html
    subroutine qneg_final(mpi_communicator, rootprocid, isrootproc,            &
-        iulog, log_output, qprops, errcode, errmsg)
+        iulog, qprops, errcode, errmsg)
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 
       integer,                           intent(in)  :: mpi_communicator
       integer,                           intent(in)  :: rootprocid
       logical,                           intent(in)  :: isrootproc
       integer,                           intent(in)  :: iulog
-      logical,                           intent(in)  :: log_output
       ! qprops is the array of constituent properties
       type(ccpp_constituent_prop_ptr_t), intent(in)  :: qprops(:)
       integer,                           intent(out) :: errcode
@@ -339,7 +337,7 @@ CONTAINS
 
       if (.not.timestep_reset .and. collect_stats) then
          call qneg_print_summary(mpi_communicator, rootprocid, isrootproc,    &
-              iulog, log_output, qprops)
+              iulog, qprops)
       end if
       deallocate(qneg_warn_num)
       deallocate(qneg_warn_worst)
@@ -347,7 +345,7 @@ CONTAINS
    end subroutine qneg_final
 
    subroutine qneg_print_summary(mpi_communicator, rootprocid, isrootproc,    &
-        iulog, log_output, qprops)
+        iulog, qprops)
       use mpi, only: MPI_MIN, MPI_SUM, MPI_INTEGER, MPI_REAL8
       use ccpp_constituent_prop_mod, only: ccpp_constituent_prop_ptr_t
 
@@ -355,7 +353,6 @@ CONTAINS
       integer,                           intent(in) :: rootprocid
       logical,                           intent(in) :: isrootproc
       integer,                           intent(in) :: iulog
-      logical,                           intent(in) :: log_output
       ! qprops is the array of constituent properties
       type(ccpp_constituent_prop_ptr_t), intent(in) :: qprops(:)
 

--- a/utilities/qneg.meta
+++ b/utilities/qneg.meta
@@ -63,7 +63,7 @@
   standard_name = ccpp_constituents
   units = kg kg-1
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension,vertical_layer_dimension,number_of_ccpp_constituents)
+  dimensions = (horizontal_loop_extent,vertical_layer_dimension,number_of_ccpp_constituents)
   intent = inout
 [ errcode ]
   standard_name = ccpp_error_code

--- a/utilities/qneg.meta
+++ b/utilities/qneg.meta
@@ -12,7 +12,7 @@
   dimensions = ()
   intent = in
 [ num_constituents_in ]
-  standard_name = ccpp_num_constituents
+  standard_name = number_of_ccpp_constituents
   units = count
   type = integer
   dimensions = ()
@@ -54,22 +54,22 @@
   dimensions = ()
   intent = in
 [ num_constituents ]
-  standard_name = ccpp_num_constituents
+  standard_name = number_of_ccpp_constituents
   units = count
   type = integer
   dimensions = ()
   intent = in
 [ qmin ]
-  standard_name = ccpp_constituent_array_minimum_values
+  standard_name = ccpp_constituent_minimum_values
   units = kg kg-1
   type = real | kind = kind_phys
-  dimensions = (ccpp_num_constituents)
+  dimensions = (number_of_ccpp_constituents)
   intent = in
 [ q ]
-  standard_name = ccpp_constituent_array
+  standard_name = ccpp_constituents
   units = kg kg-1
   type = real | kind = kind_phys
-  dimensions = (horizontal_dimension,vertical_layer_dimension,ccpp_num_constituents)
+  dimensions = (horizontal_dimension,vertical_layer_dimension,number_of_ccpp_constituents)
   intent = inout
 [ errcode ]
   standard_name = ccpp_error_code
@@ -102,7 +102,7 @@
   dimensions = ()
   intent = in
 [ isrootproc ]
-  standard_name = is_mpi_root
+  standard_name = flag_for_mpi_root
   units = flag
   type = logical
   dimensions = ()
@@ -120,10 +120,10 @@
   dimensions = ()
   intent = in
 [ qprops ]
-  standard_name = ccpp_constituent_properties_array
+  standard_name = ccpp_constituent_properties
   units = None
   type = ccpp_constituent_prop_ptr_t
-  dimensions = (ccpp_num_constituents)
+  dimensions = (number_of_ccpp_constituents)
   intent = in
 [ errcode ]
   standard_name = ccpp_error_code
@@ -156,7 +156,7 @@
   dimensions = ()
   intent = in
 [ isrootproc ]
-  standard_name = is_mpi_root
+  standard_name = flag_for_mpi_root
   units = flag
   type = logical
   dimensions = ()
@@ -168,10 +168,10 @@
   dimensions = ()
   intent = in
 [ qprops ]
-  standard_name = ccpp_constituent_properties_array
+  standard_name = ccpp_constituent_properties
   units = None
   type = ccpp_constituent_prop_ptr_t
-  dimensions = (ccpp_num_constituents)
+  dimensions = (number_of_ccpp_constituents)
   intent = in
 [ errcode ]
   standard_name = ccpp_error_code

--- a/utilities/qneg.meta
+++ b/utilities/qneg.meta
@@ -17,12 +17,6 @@
   type = integer
   dimensions = ()
   intent = in
-[ qprops ]
-  standard_name = ccpp_constituent_properties_array
-  units = None
-  type = ccpp_constituent_prop_ptr_t
-  dimensions = (ccpp_num_constituents)
-  intent = in
 [ errcode ]
   standard_name = ccpp_error_code
   long_name = Error flag for error handling in CCPP
@@ -43,7 +37,7 @@
   type  = scheme
 [ subnam ]
   standard_name = scheme_name
-  units = 1
+  units = none
   type = character | kind = len=*
   dimensions = ()
   intent = in
@@ -69,12 +63,6 @@
   standard_name = ccpp_constituent_array_minimum_values
   units = kg kg-1
   type = real | kind = kind_phys
-  dimensions = (ccpp_num_constituents)
-  intent = in
-[ qprops ]
-  standard_name = ccpp_constituent_properties_array
-  units = None
-  type = ccpp_constituent_prop_ptr_t
   dimensions = (ccpp_num_constituents)
   intent = in
 [ q ]

--- a/utilities/qneg.meta
+++ b/utilities/qneg.meta
@@ -86,7 +86,6 @@
 [ q ]
   standard_name = ccpp_constituent_array
   units = kg kg-1
-  state_variable = true
   type = real | kind = kind_phys
   dimensions = (horizontal_dimension,vertical_layer_dimension,ccpp_num_constituents)
   intent = inout

--- a/utilities/qneg.meta
+++ b/utilities/qneg.meta
@@ -53,12 +53,6 @@
   type = integer
   dimensions = ()
   intent = in
-[ num_constituents ]
-  standard_name = number_of_ccpp_constituents
-  units = count
-  type = integer
-  dimensions = ()
-  intent = in
 [ qmin ]
   standard_name = ccpp_constituent_minimum_values
   units = kg kg-1
@@ -111,12 +105,6 @@
   standard_name = log_output_unit
   units = 1
   type = integer
-  dimensions = ()
-  intent = in
-[ log_output ]
-  standard_name = do_log_output
-  units = flag
-  type = logical
   dimensions = ()
   intent = in
 [ qprops ]

--- a/utilities/qneg.meta
+++ b/utilities/qneg.meta
@@ -47,14 +47,8 @@
   type = character | kind = len=*
   dimensions = ()
   intent = in
-[ loop_begin ]
-  standard_name = horizontal_loop_begin
-  units = count
-  type = integer
-  dimensions = ()
-  intent = in
-[ loop_end ]
-  standard_name = horizontal_loop_end
+[ num_columns ]
+  standard_name = horizontal_loop_extent
   units = count
   type = integer
   dimensions = ()
@@ -183,12 +177,6 @@
   standard_name = log_output_unit
   units = 1
   type = integer
-  dimensions = ()
-  intent = in
-[ log_output ]
-  standard_name = do_log_output
-  units = flag
-  type = logical
   dimensions = ()
   intent = in
 [ qprops ]

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -70,10 +70,10 @@ CONTAINS
 
 !> \section arg_table_pres_to_density_dry_run  Argument Table
 !! \htmlinclude pres_to_density_dry_run.html
-  subroutine pres_to_density_dry_run(ncol, nz, rdair, pmiddry, temp, rho, errmsg, errflg)
+  subroutine pres_to_density_dry_run(ncol, nz, rair, pmiddry, temp, rho, errmsg, errflg)
     integer,          intent(in)    :: ncol         ! Number of columns
     integer,          intent(in)    :: nz           ! Number of vertical levels
-    real(kind_phys),  intent(in)    :: rdair        ! gas constant for dry air (J kg-1)
+    real(kind_phys),  intent(in)    :: rair(:,:)   ! gas constant for dry air (J kg-1)
     real(kind_phys),  intent(in)    :: pmiddry(:,:) ! Air pressure of dry air (Pa)
     real(kind_phys),  intent(in)    :: temp(:,:)    ! Air temperature (K)
     real(kind_phys),  intent(out)   :: rho(:,:)     ! Dry air density (kg m-3)
@@ -83,7 +83,7 @@ CONTAINS
     integer :: k
 
     do k = 1, nz
-      rho(:ncol,k) = pmiddry(:ncol,k)/(rdair*temp(:ncol,k))
+      rho(:ncol,k) = pmiddry(:ncol,k)/(rair(:ncol,k)*temp(:ncol,k))
     end do
 
     errmsg = ''
@@ -98,8 +98,8 @@ CONTAINS
 
     integer,          intent(in)  :: ncol       ! Number of columns
     integer,          intent(in)  :: nz         ! Number of vertical levels
-    real(kind_phys),  intent(in)  :: rair       ! Gas constant for dry air (J kg-1)
-    real(kind_phys),  intent(in)  :: cpair      ! Heat capacity at constant pressure (J kg-1)
+    real(kind_phys),  intent(in)  :: rair(:,:)  ! Gas constant for dry air (J kg-1)
+    real(kind_phys),  intent(in)  :: cpair(:,:) ! Heat capacity at constant pressure (J kg-1)
     real(kind_phys),  intent(in)  :: ref_pres   ! Reference pressure (Pa)
     real(kind_phys),  intent(in)  :: pmid(:,:)  ! Mid-point air pressure (Pa)
     real(kind_phys),  intent(out) :: exner(:,:) ! Exner function
@@ -109,7 +109,7 @@ CONTAINS
     integer :: i
 
     do i=1,nz
-      exner(:ncol,i) = (pmid(:ncol,i)/ref_pres)**(rair/cpair)
+      exner(:ncol,i) = (pmid(:ncol,i)/ref_pres)**(rair(:ncol,i)/cpair(:ncol,i))
     end do
 
     errflg = 0

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -10,8 +10,8 @@ module state_converters
   public :: temp_to_potential_temp_run
   public :: potential_temp_to_temp_run
 
-  ! Convert dry pressure to dry air density
-  public :: pres_to_density_dry_run
+  ! Calculate density from equation of state/ideal gas law
+  public :: calc_dry_ideal_gas_density_run
 
   ! Calculate exner
   public :: calc_exner_run
@@ -68,9 +68,9 @@ CONTAINS
     errmsg = ''
   end subroutine potential_temp_to_temp_run
 
-!> \section arg_table_pres_to_density_dry_run  Argument Table
-!! \htmlinclude pres_to_density_dry_run.html
-  subroutine pres_to_density_dry_run(ncol, nz, rair, pmiddry, temp, rho, errmsg, errflg)
+!> \section arg_table_calc_dry_ideal_gas_density_run  Argument Table
+!! \htmlinclude calc_dry_ideal_gas_density_run.html
+  subroutine calc_dry_ideal_gas_density_run(ncol, nz, rair, pmiddry, temp, rho, errmsg, errflg)
     integer,          intent(in)    :: ncol         ! Number of columns
     integer,          intent(in)    :: nz           ! Number of vertical levels
     real(kind_phys),  intent(in)    :: rair(:,:)   ! gas constant for dry air (J kg-1)
@@ -89,7 +89,7 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine pres_to_density_dry_run
+  end subroutine calc_dry_ideal_gas_density_run
 
 !> \section arg_table_calc_exner_run  Argument Table
 !! \htmlinclude calc_exner_run.html

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -137,7 +137,7 @@ CONTAINS
      errmsg = ''
 
      do k = 1, nz
-       qv_dry(:ncol,k) = qv(:ncol,k) * pdel(:ncol,k) / pdeldry(:ncol,k)
+       qv_dry(:ncol,k) = qv(:ncol,k) * (pdel(:ncol,k) / pdeldry(:ncol,k))
      end do
 
   end subroutine wet_to_dry_water_vapor_run
@@ -162,7 +162,7 @@ CONTAINS
      errmsg = ''
 
      do k = 1, nz
-       qc_dry(:ncol,k) = qc(:ncol,k) * pdel(:ncol,k) / pdeldry(:ncol,k)
+       qc_dry(:ncol,k) = qc(:ncol,k) * (pdel(:ncol,k) / pdeldry(:ncol,k))
      end do
 
   end subroutine wet_to_dry_cloud_liquid_water_run
@@ -187,7 +187,7 @@ CONTAINS
      errmsg = ''
 
      do k = 1, nz
-       qr_dry(:ncol,k) = qr(:ncol,k) * pdel(:ncol,k) / pdeldry(:ncol,k)
+       qr_dry(:ncol,k) = qr(:ncol,k) * (pdel(:ncol,k) / pdeldry(:ncol,k))
      end do
 
   end subroutine wet_to_dry_rain_run
@@ -212,7 +212,7 @@ CONTAINS
      errmsg = ''
 
      do k = 1, nz
-       qv(:ncol,k) = qv_dry(:ncol,k) * pdeldry(:ncol,k) / pdel(:ncol,k)
+       qv(:ncol,k) = qv_dry(:ncol,k) * (pdeldry(:ncol,k) / pdel(:ncol,k))
      end do
 
   end subroutine dry_to_wet_water_vapor_run
@@ -237,7 +237,7 @@ CONTAINS
      errmsg = ''
 
      do k = 1, nz
-       qc(:ncol,k) = qc_dry(:ncol,k) * pdeldry(:ncol,k) / pdel(:ncol,k)
+       qc(:ncol,k) = qc_dry(:ncol,k) * (pdeldry(:ncol,k) / pdel(:ncol,k))
      end do
 
   end subroutine dry_to_wet_cloud_liquid_water_run
@@ -262,7 +262,7 @@ CONTAINS
      errmsg = ''
 
      do k = 1, nz
-       qr(:ncol,k) = qr_dry(:ncol,k) * pdeldry(:ncol,k) / pdel(:ncol,k)
+       qr(:ncol,k) = qr_dry(:ncol,k) * (pdeldry(:ncol,k) / pdel(:ncol,k))
      end do
 
   end subroutine dry_to_wet_rain_run

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -158,12 +158,14 @@ CONTAINS
 
 !> \section arg_table_calc_exner_run  Argument Table
 !! \htmlinclude calc_exner_run.html
-  subroutine calc_exner_run(ncol, nz, cpair, rair, pmid, exner, errmsg, errflg)
+  subroutine calc_exner_run(ncol, nz, cpair, rair, ref_pres, pmid, exner,     &
+       errmsg, errflg)
 
     integer,          intent(in)  :: ncol       ! Number of columns
     integer,          intent(in)  :: nz         ! Number of vertical levels
-    real(kind_phys),  intent(in)  :: rair  ! gas constant for dry air
-    real(kind_phys),  intent(in)  :: cpair ! heat capacity at constant pressure
+    real(kind_phys),  intent(in)  :: rair       ! Gas constant for dry air
+    real(kind_phys),  intent(in)  :: cpair      ! Heat capacity at constant pressure
+    real(kind_phys),  intent(in)  :: ref_pres   ! Reference pressure
     real(kind_phys),  intent(in)  :: pmid(:,:)
     real(kind_phys),  intent(out) :: exner(:,:)
     character(len=*), intent(out) :: errmsg
@@ -172,7 +174,7 @@ CONTAINS
     integer :: i
 
     do i=1,nz
-      exner(:ncol,i) = (pmid(:ncol,i)/1.e5_kind_phys)**(rair/cpair)
+      exner(:ncol,i) = (pmid(:ncol,i)/ref_pres)**(rair/cpair)
     end do
 
     errflg = 0

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -70,7 +70,7 @@ CONTAINS
 
 !> \section arg_table_calc_dry_air_ideal_gas_density_run  Argument Table
 !! \htmlinclude calc_dry_air_ideal_gas_density_run.html
-  subroutine calc_dry_ideal_gas_density_run(ncol, nz, rair, pmiddry, temp, rho, errmsg, errflg)
+  subroutine calc_dry_air_ideal_gas_density_run(ncol, nz, rair, pmiddry, temp, rho, errmsg, errflg)
     integer,          intent(in)    :: ncol         ! Number of columns
     integer,          intent(in)    :: nz           ! Number of vertical levels
     real(kind_phys),  intent(in)    :: rair(:,:)   ! gas constant for dry air (J kg-1)

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -126,7 +126,7 @@ CONTAINS
      integer,          intent(in)  :: nz
      real(kind_phys),  intent(in)  :: pdel(:,:)    ! pressure thickness of layer (Pa)
      real(kind_phys),  intent(in)  :: pdeldry(:,:) ! dry air pressure thickness of layer (Pa)
-     real(kind_phys),  intent(in)  :: qv(:,:)      ! water vapor mixing ratio wrt moist air (kg/kg)
+     real(kind_phys),  intent(in)  :: qv(:,:)      ! water vapor mixing ratio wrt moist air + condensates (kg/kg)
      real(kind_phys),  intent(out) :: qv_dry(:,:)  ! water vapor mixing ratio wrt dry air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
@@ -202,7 +202,7 @@ CONTAINS
      real(kind_phys),  intent(in)  :: pdel(:,:)     ! pressure thickness of layer (Pa)
      real(kind_phys),  intent(in)  :: pdeldry(:,:)  ! dry air pressure thickness of layer (Pa)
      real(kind_phys),  intent(in)  :: qv_dry(:,:)   ! water vapor mixing ratio wrt dry air (kg/kg)
-     real(kind_phys),  intent(out) :: qv(:,:)       ! water vapor mixing ratio wrt moist air (kg/kg)
+     real(kind_phys),  intent(out) :: qv(:,:)       ! water vapor mixing ratio wrt moist air + condensates (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -98,8 +98,8 @@ CONTAINS
 
     integer,          intent(in)  :: ncol       ! Number of columns
     integer,          intent(in)  :: nz         ! Number of vertical levels
-    real(kind_phys),  intent(in)  :: rair(:,:)  ! Gas constant for dry air (J kg-1)
-    real(kind_phys),  intent(in)  :: cpair(:,:) ! Heat capacity at constant pressure (J kg-1)
+    real(kind_phys),  intent(in)  :: rair(:,:)  ! Gas constant for dry air (J kg-1 K-1)
+    real(kind_phys),  intent(in)  :: cpair(:,:) ! Heat capacity at constant pressure (J kg-1 K-1)
     real(kind_phys),  intent(in)  :: ref_pres   ! Reference pressure (Pa)
     real(kind_phys),  intent(in)  :: pmid(:,:)  ! Mid-point air pressure (Pa)
     real(kind_phys),  intent(out) :: exner(:,:) ! Exner function

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -11,7 +11,7 @@ module state_converters
   public :: potential_temp_to_temp_run
 
   ! Calculate density from equation of state/ideal gas law
-  public :: calc_dry_ideal_gas_density_run
+  public :: calc_dry_air_ideal_gas_density_run
 
   ! Calculate exner
   public :: calc_exner_run
@@ -68,8 +68,8 @@ CONTAINS
     errmsg = ''
   end subroutine potential_temp_to_temp_run
 
-!> \section arg_table_calc_dry_ideal_gas_density_run  Argument Table
-!! \htmlinclude calc_dry_ideal_gas_density_run.html
+!> \section arg_table_calc_dry_air_ideal_gas_density_run  Argument Table
+!! \htmlinclude calc_dry_air_ideal_gas_density_run.html
   subroutine calc_dry_ideal_gas_density_run(ncol, nz, rair, pmiddry, temp, rho, errmsg, errflg)
     integer,          intent(in)    :: ncol         ! Number of columns
     integer,          intent(in)    :: nz           ! Number of vertical levels
@@ -89,7 +89,7 @@ CONTAINS
     errmsg = ''
     errflg = 0
 
-  end subroutine calc_dry_ideal_gas_density_run
+  end subroutine calc_dry_air_ideal_gas_density_run
 
 !> \section arg_table_calc_exner_run  Argument Table
 !! \htmlinclude calc_exner_run.html

--- a/utilities/state_converters.F90
+++ b/utilities/state_converters.F90
@@ -11,11 +11,9 @@ module state_converters
   public :: potential_temp_to_temp_run
 
   ! Convert dry pressure to dry air density
-  public :: pres_to_density_dry_init
   public :: pres_to_density_dry_run
 
   ! Calculate exner
-  public :: calc_exner_init
   public :: calc_exner_run
 
   ! Convert between wet and dry
@@ -26,48 +24,16 @@ module state_converters
   public :: dry_to_wet_cloud_liquid_water_run
   public :: dry_to_wet_rain_run
 
-  ! Private module data (constants set at initialization)
-  real(kind_phys), parameter :: unset = 98989.8e99_kind_phys
-  real(kind_phys) :: rd = unset    ! gas constant for dry air, J/(kgK)
-  real(kind_phys) :: cp = unset    ! heat capacity at constant pressure, J/(kgK)
-
-  ! Private interfaces
-  private :: safe_set ! Set constants checking for consistency
-
 CONTAINS
-
-  subroutine safe_set(var, set_val, var_name, errmsg, errflg)
-    ! Dummy arguments
-    real(kind_phys),  intent(inout):: var     ! variable to set
-    real(kind_phys),  intent(in)  :: set_val ! value to set
-    character(len=*), intent(in)  :: var_name
-    character(len=*), intent(out) :: errmsg
-    integer,          intent(out) :: errflg
-
-    if (var == unset) then
-      ! var has not been set, just set it
-      var = set_val
-      errflg = 0
-      errmsg = ''
-    else if (var /= set_val) then
-      errflg = 1
-      errmsg = 'attempt to set '//trim(var_name)//' to inconsistent value'
-    else
-      ! var is already set to correct value, no error
-      errflg = 0
-      errmsg = ''
-    end if
-
-  end subroutine safe_set
 
 !> \section arg_table_temp_to_potential_temp_run  Argument Table
 !! \htmlinclude temp_to_potential_temp_run.html
   subroutine temp_to_potential_temp_run(ncol, nz, temp, exner, theta, errmsg, errflg)
     ! Dummy arguments
-    integer,          intent(in)  :: ncol       ! Number of columns
-    integer,          intent(in)  :: nz         ! Number of vertical levels
+    integer,          intent(in)  :: ncol              ! Number of columns
+    integer,          intent(in)  :: nz                ! Number of vertical levels
     real(kind_phys),         intent(in)  :: temp(:,:)  ! temperature (K)
-    real(kind_phys),         intent(in)  :: exner(:,:) ! inverse exner function
+    real(kind_phys),         intent(in)  :: exner(:,:) ! exner function
     real(kind_phys),         intent(out) :: theta(:,:) ! potential temperature (K)
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
@@ -85,11 +51,11 @@ CONTAINS
 !! \htmlinclude potential_temp_to_temp_run.html
   subroutine potential_temp_to_temp_run(ncol, nz, theta, exner, temp, errmsg, errflg)
     ! Dummy arguments
-    integer,          intent(in)  :: ncol       ! Number of columns
-    integer,          intent(in)  :: nz         ! Number of vertical levels
-    real(kind_phys),         intent(in)  :: theta(:,:) ! potential temperature (K)
-    real(kind_phys),         intent(in)  :: exner(:,:) ! inverse exner function
-    real(kind_phys),         intent(inout) :: temp(:,:)  ! temperature (K)
+    integer,          intent(in)  :: ncol               ! Number of columns
+    integer,          intent(in)  :: nz                 ! Number of vertical levels
+    real(kind_phys),         intent(in)  :: theta(:,:)  ! potential temperature (K)
+    real(kind_phys),         intent(in)  :: exner(:,:)  ! exner function
+    real(kind_phys),         intent(inout) :: temp(:,:) ! temperature (K)
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
     ! Local variable
@@ -102,59 +68,28 @@ CONTAINS
     errmsg = ''
   end subroutine potential_temp_to_temp_run
 
-!> \section arg_table_pres_to_density_dry_init  Argument Table
-!! \htmlinclude res_to_density_dry_init.html
-  subroutine pres_to_density_dry_init(cpair, rair, errmsg, errflg)
-    real(kind_phys),  intent(in)  :: rair  ! gas constant for dry air
-    real(kind_phys),  intent(in)  :: cpair ! heat capacity at constant pressure
-    character(len=*), intent(out) :: errmsg
-    integer,          intent(out) :: errflg
-
-    call safe_set(cp, cpair, 'cpair', errmsg, errflg)
-    if (errflg /= 0) then
-      errmsg = 'pres_to_density_dry_init: '//trim(errmsg)
-    else
-      call safe_set(rd, rair, 'rair', errmsg, errflg)
-      if (errflg /= 0) then
-        errmsg = 'pres_to_density_dry_init: '//trim(errmsg)
-      end if
-    end if
-
-  end subroutine pres_to_density_dry_init
-
 !> \section arg_table_pres_to_density_dry_run  Argument Table
 !! \htmlinclude pres_to_density_dry_run.html
-  subroutine pres_to_density_dry_run(ncol, nz, pmiddry, temp, rho, errmsg, errflg)
-    integer,          intent(in)    :: ncol      ! Number of columns
-    integer,          intent(in)    :: nz        ! Number of vertical levels
-    real(kind_phys),  intent(in)    :: pmiddry(:,:)
-    real(kind_phys),  intent(in)    :: temp(:,:)
-    real(kind_phys),         intent(out)   :: rho(:,:)  ! Dry air density (kg/m^3)
+  subroutine pres_to_density_dry_run(ncol, nz, rdair, pmiddry, temp, rho, errmsg, errflg)
+    integer,          intent(in)    :: ncol         ! Number of columns
+    integer,          intent(in)    :: nz           ! Number of vertical levels
+    real(kind_phys),  intent(in)    :: rdair        ! gas constant for dry air (J kg-1)
+    real(kind_phys),  intent(in)    :: pmiddry(:,:) ! Air pressure of dry air (Pa)
+    real(kind_phys),  intent(in)    :: temp(:,:)    ! Air temperature (K)
+    real(kind_phys),  intent(out)   :: rho(:,:)     ! Dry air density (kg m-3)
     character(len=*), intent(out)   :: errmsg
     integer,          intent(out)   :: errflg
 
     integer :: k
 
     do k = 1, nz
-      rho(:ncol,k) = pmiddry(:ncol,k)/(rd*temp(:ncol,k))
+      rho(:ncol,k) = pmiddry(:ncol,k)/(rdair*temp(:ncol,k))
     end do
 
     errmsg = ''
     errflg = 0
 
   end subroutine pres_to_density_dry_run
-
-!> \section arg_table_calc_exner_init  Argument Table
-!! \htmlinclude calc_exner_init.html
-  subroutine calc_exner_init(errmsg, errflg)
-
-    character(len=*), intent(out) :: errmsg
-    integer,          intent(out) :: errflg
-
-    errflg = 0
-    errmsg = ''
-
-  end subroutine calc_exner_init
 
 !> \section arg_table_calc_exner_run  Argument Table
 !! \htmlinclude calc_exner_run.html
@@ -163,11 +98,11 @@ CONTAINS
 
     integer,          intent(in)  :: ncol       ! Number of columns
     integer,          intent(in)  :: nz         ! Number of vertical levels
-    real(kind_phys),  intent(in)  :: rair       ! Gas constant for dry air
-    real(kind_phys),  intent(in)  :: cpair      ! Heat capacity at constant pressure
-    real(kind_phys),  intent(in)  :: ref_pres   ! Reference pressure
-    real(kind_phys),  intent(in)  :: pmid(:,:)
-    real(kind_phys),  intent(out) :: exner(:,:)
+    real(kind_phys),  intent(in)  :: rair       ! Gas constant for dry air (J kg-1)
+    real(kind_phys),  intent(in)  :: cpair      ! Heat capacity at constant pressure (J kg-1)
+    real(kind_phys),  intent(in)  :: ref_pres   ! Reference pressure (Pa)
+    real(kind_phys),  intent(in)  :: pmid(:,:)  ! Mid-point air pressure (Pa)
+    real(kind_phys),  intent(out) :: exner(:,:) ! Exner function
     character(len=*), intent(out) :: errmsg
     integer,          intent(out) :: errflg
 
@@ -189,14 +124,14 @@ CONTAINS
 
      integer,          intent(in)  :: ncol
      integer,          intent(in)  :: nz
-     real(kind_phys),  intent(in)  :: pdel(:,:)
-     real(kind_phys),  intent(in)  :: pdeldry(:,:)
-     real(kind_phys),  intent(in)  :: qv(:,:)
-     real(kind_phys),  intent(out) :: qv_dry(:,:)
+     real(kind_phys),  intent(in)  :: pdel(:,:)    ! pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: pdeldry(:,:) ! dry air pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: qv(:,:)      ! water vapor mixing ratio wrt moist air (kg/kg)
+     real(kind_phys),  intent(out) :: qv_dry(:,:)  ! water vapor mixing ratio wrt dry air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 
-     integer         :: k
+     integer :: k
 
      errflg = 0
      errmsg = ''
@@ -214,14 +149,14 @@ CONTAINS
 
      integer,          intent(in)  :: ncol
      integer,          intent(in)  :: nz
-     real(kind_phys),  intent(in)  :: pdel(:,:)
-     real(kind_phys),  intent(in)  :: pdeldry(:,:)
-     real(kind_phys),  intent(in)  :: qc(:,:)
-     real(kind_phys),  intent(out) :: qc_dry(:,:)
+     real(kind_phys),  intent(in)  :: pdel(:,:)    ! pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: pdeldry(:,:) ! dry air pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: qc(:,:)      ! cloud liquid mixing ratio wrt moist air (kg/kg)
+     real(kind_phys),  intent(out) :: qc_dry(:,:)  ! cloud liquid mixing ratio wrt dry air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 
-     integer         :: k
+     integer :: k
 
      errflg = 0
      errmsg = ''
@@ -239,14 +174,14 @@ CONTAINS
 
      integer,          intent(in)  :: ncol
      integer,          intent(in)  :: nz
-     real(kind_phys),  intent(in)  :: pdel(:,:)
-     real(kind_phys),  intent(in)  :: pdeldry(:,:)
-     real(kind_phys),  intent(in)  :: qr(:,:)
-     real(kind_phys),  intent(out) :: qr_dry(:,:)
+     real(kind_phys),  intent(in)  :: pdel(:,:)     ! pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: pdeldry(:,:)  ! dry air pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: qr(:,:)       ! rain mixing ratio wrt moist air (kg/kg)
+     real(kind_phys),  intent(out) :: qr_dry(:,:)   ! rain mixing ratio wrt dry air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 
-     integer         :: k
+     integer :: k
 
      errflg = 0
      errmsg = ''
@@ -264,14 +199,14 @@ CONTAINS
 
      integer,          intent(in)  :: ncol
      integer,          intent(in)  :: nz
-     real(kind_phys),  intent(in)  :: pdel(:,:)
-     real(kind_phys),  intent(in)  :: pdeldry(:,:)
-     real(kind_phys),  intent(in)  :: qv_dry(:,:)
-     real(kind_phys),  intent(out) :: qv(:,:)
+     real(kind_phys),  intent(in)  :: pdel(:,:)     ! pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: pdeldry(:,:)  ! dry air pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: qv_dry(:,:)   ! water vapor mixing ratio wrt dry air (kg/kg)
+     real(kind_phys),  intent(out) :: qv(:,:)       ! water vapor mixing ratio wrt moist air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 
-     integer  :: k
+     integer :: k
 
      errflg = 0
      errmsg = ''
@@ -289,10 +224,10 @@ CONTAINS
 
      integer,          intent(in)  :: ncol
      integer,          intent(in)  :: nz
-     real(kind_phys),  intent(in)  :: pdel(:,:)
-     real(kind_phys),  intent(in)  :: pdeldry(:,:)
-     real(kind_phys),  intent(in)  :: qc_dry(:,:)
-     real(kind_phys),  intent(out) :: qc(:,:)
+     real(kind_phys),  intent(in)  :: pdel(:,:)    ! pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: pdeldry(:,:) ! dry air pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: qc_dry(:,:)  ! cloud liquid mixing ratio wrt dry air (kg/kg)
+     real(kind_phys),  intent(out) :: qc(:,:)      ! cloud liquid mixing ratio wrt moist air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 
@@ -314,10 +249,10 @@ CONTAINS
 
      integer,          intent(in)  :: ncol
      integer,          intent(in)  :: nz
-     real(kind_phys),  intent(in)  :: pdel(:,:)
-     real(kind_phys),  intent(in)  :: pdeldry(:,:)
-     real(kind_phys),  intent(in)  :: qr_dry(:,:)
-     real(kind_phys),  intent(out) :: qr(:,:)
+     real(kind_phys),  intent(in)  :: pdel(:,:)    ! pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: pdeldry(:,:) ! dry air pressure thickness of layer (Pa)
+     real(kind_phys),  intent(in)  :: qr_dry(:,:)  ! rain mixing ratio wrt dry air (kg/kg)
+     real(kind_phys),  intent(out) :: qr(:,:)      ! rain mixing ratio wrt moist air (kg/kg)
      character(len=*), intent(out) :: errmsg
      integer,          intent(out) :: errflg
 

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -134,7 +134,7 @@
 [ rair ]
   standard_name = composition_dependent_gas_constant_of_dry_air
   long_name = dry air gas constant
-  units = J kg-1
+  units = J kg-1 K-1
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
@@ -174,6 +174,9 @@
    intent = out
 
 #########################################################
+[ccpp-table-properties]
+  name = calc_exner
+  type = scheme
 [ccpp-arg-table]
   name = calc_exner_run
   type = scheme

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -252,8 +252,15 @@
   intent = in
 [ rair ]
   standard_name = gas_constant_of_dry_air
-  long_name = long_name="ideal gas constant for dry air
+  long_name = ideal gas constant for dry air
   units = J kg-1 K-1
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
+[ ref_pres ]
+  standard_name = reference_pressure
+  long_name = reference pressure used in definition of potential temperature, Exner function, etc.
+  units = Pa
   dimensions = ()
   type = real | kind = kind_phys
   intent = in

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -112,10 +112,10 @@
 
 #########################################################
 [ccpp-table-properties]
-  name = calc_dry_ideal_gas_density
+  name = calc_dry_air_ideal_gas_density
   type = scheme
 [ccpp-arg-table]
-  name = calc_dry_ideal_gas_density_run
+  name = calc_dry_air_ideal_gas_density_run
   type = scheme
 [ ncol ]
   standard_name = horizontal_loop_extent

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -131,11 +131,11 @@
   dimensions = ()
   type = integer
   intent = in
-[ rdair ]
+[ rair ]
   standard_name = composition_dependent_gas_constant_of_dry_air
   long_name = dry air gas constant
   units = J kg-1
-  dimensions = ()
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ pmiddry ]
@@ -194,14 +194,14 @@
 [ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
-  dimensions = ()
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ rair ]
   standard_name = composition_dependent_gas_constant_of_dry_air
   long_name = ideal gas constant for dry air
   units = J kg-1 K-1
-  dimensions = ()
+  dimensions = (horizontal_dimension, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ ref_pres ]

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -112,10 +112,10 @@
 
 #########################################################
 [ccpp-table-properties]
-  name = pres_to_density_dry
+  name = calc_dry_ideal_gas_density
   type = scheme
 [ccpp-arg-table]
-  name = pres_to_density_dry_run
+  name = calc_dry_ideal_gas_density_run
   type = scheme
 [ ncol ]
   standard_name = horizontal_loop_extent

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -25,14 +25,14 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ exner ]
-  standard_name = inverse_exner_function_wrt_surface_pressure
-  long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
-  units = count
+  standard_name = dimensionless_exner_function
+  long_name = exner function
+  units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ theta ]
-  standard_name = potential_temperature
+  standard_name = air_potential_temperature
   long_name = potential temperature
   units = K
   type = real | kind = kind_phys
@@ -76,16 +76,16 @@
   dimensions = ()
   intent = in
 [ theta ]
-  standard_name = potential_temperature
+  standard_name = air_potential_temperature
   long_name = potential temperature
   units = K
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ exner ]
-  standard_name = inverse_exner_function_wrt_surface_pressure
-  long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
-  units = count
+  standard_name = dimensionless_exner_function
+  long_name = exner function
+  units = 1
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
@@ -115,38 +115,6 @@
   name = pres_to_density_dry
   type = scheme
 [ccpp-arg-table]
-  name = pres_to_density_dry_init
-  type = scheme
-[ cpair ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
-  units = J kg-1 K-1
-  dimensions = ()
-  type = real | kind = kind_phys
-  intent = in
-[ rair ]
-  standard_name = gas_constant_of_dry_air
-  long_name = long_name="ideal gas constant for dry air
-  units = J kg-1 K-1
-  dimensions = ()
-  type = real | kind = kind_phys
-  intent = in
-[ errmsg ]
-   standard_name = ccpp_error_message
-   long_name = Error message for error handling in CCPP
-   units = none
-   dimensions = ()
-   type = character | kind = len=*
-   intent = out
-[ errflg ]
-   standard_name = ccpp_error_code
-   long_name = Error flag for error handling in CCPP
-   units = 1
-   dimensions = ()
-   type = integer
-   intent = out
-
-#########################################################
-[ccpp-arg-table]
   name = pres_to_density_dry_run
   type = scheme
 [ ncol ]
@@ -163,6 +131,13 @@
   dimensions = ()
   type = integer
   intent = in
+[ rdair ]
+  standard_name = composition_dependent_gas_constant_of_dry_air
+  long_name = dry air gas constant
+  units = J kg-1
+  dimensions = ()
+  type = real | kind = kind_phys
+  intent = in
 [ pmiddry ]
   standard_name = air_pressure_of_dry_air
   long_name = Dry midpoint pressure
@@ -177,34 +152,12 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ rho ]
-   standard_name = dry_air_density
+   standard_name = density_of_dry_air
    long_name = dry air density
    units = kg m-3
    dimensions = (horizontal_loop_extent, vertical_layer_dimension)
    type = real | kind = kind_phys
    intent = out
-[ errmsg ]
-   standard_name = ccpp_error_message
-   long_name = Error message for error handling in CCPP
-   units = none
-   dimensions = ()
-   type = character | kind = len=*
-   intent = out
-[ errflg ]
-   standard_name = ccpp_error_code
-   long_name = Error flag for error handling in CCPP
-   units = 1
-   dimensions = ()
-   type = integer
-   intent = out
-
-#########################################################
-[ccpp-table-properties]
-  name = calc_exner
-  type = scheme
-[ccpp-arg-table]
-  name = calc_exner_init
-  type = scheme
 [ errmsg ]
    standard_name = ccpp_error_message
    long_name = Error message for error handling in CCPP
@@ -239,13 +192,13 @@
   dimensions = ()
   intent = in
 [ cpair ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
   dimensions = ()
   type = real | kind = kind_phys
   intent = in
 [ rair ]
-  standard_name = gas_constant_of_dry_air
+  standard_name = composition_dependent_gas_constant_of_dry_air
   long_name = ideal gas constant for dry air
   units = J kg-1 K-1
   dimensions = ()
@@ -265,7 +218,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ exner ]
-  standard_name = inverse_exner_function_wrt_surface_pressure
+  standard_name = dimensionless_exner_function
   type = real | kind = kind_phys
   units = count
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -306,19 +259,19 @@
   type = integer
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdeldry ]
-  standard_name = pressure_thickness_of_dry_air
+  standard_name = air_pressure_thickness_of_dry_air
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qv ]
-  standard_name = specific_humidity
+  standard_name = water_vapor_mixing_ratio_wrt_moist_air
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -366,13 +319,13 @@
   type = integer
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdeldry ]
-  standard_name = pressure_thickness_of_dry_air
+  standard_name = air_pressure_thickness_of_dry_air
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -428,19 +381,19 @@
   type = integer
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdeldry ]
-  standard_name = pressure_thickness_of_dry_air
+  standard_name = air_pressure_thickness_of_dry_air
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_water_mixing_ratio_wrt_moist_air
+  standard_name = rain__mixing_ratio_wrt_moist_air
   long_name = Mass mixing ratio of rain / moist air
   advected = True
   type = real | kind = kind_phys
@@ -448,7 +401,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr_dry ]
-  standard_name = rain_water_mixing_ratio_wrt_dry_air
+  standard_name = rain_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
   type = real | kind = kind_phys
   units = kg kg-1
@@ -490,13 +443,13 @@
   type = integer
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdeldry ]
-  standard_name = pressure_thickness_of_dry_air
+  standard_name = air_pressure_thickness_of_dry_air
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -509,7 +462,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qv ]
-  standard_name = specific_humidity
+  standard_name = water_vapor_mixing_ratio_wrt_moist_air
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -550,13 +503,13 @@
   type = integer
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdeldry ]
-  standard_name = pressure_thickness_of_dry_air
+  standard_name = air_pressure_thickness_of_dry_air
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -611,26 +564,26 @@
   type = integer
   intent = in
 [ pdel ]
-  standard_name = pressure_thickness
+  standard_name = air_pressure_thickness
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ pdeldry ]
-  standard_name = pressure_thickness_of_dry_air
+  standard_name = air_pressure_thickness_of_dry_air
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr_dry ]
-  standard_name = rain_water_mixing_ratio_wrt_dry_air
+  standard_name = rain_mixing_ratio_wrt_dry_air
   long_name = Mass mixing ratio of rain / dry air
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_water_mixing_ratio_wrt_moist_air
+  standard_name = rain_mixing_ratio_wrt_moist_air
   long_name = Mass mixing ratio of rain / moist_air
   type = real | kind = kind_phys
   units = kg kg-1

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -20,7 +20,6 @@
   intent = in
 [ temp ]
   standard_name = air_temperature
-  state_variable = true
   units = K
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -28,7 +27,6 @@
 [ exner ]
   standard_name = inverse_exner_function_wrt_surface_pressure
   long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
-  state_variable = true
   units = count
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -87,14 +85,12 @@
 [ exner ]
   standard_name = inverse_exner_function_wrt_surface_pressure
   long_name = inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
-  state_variable = true
   units = count
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ temp ]
   standard_name = air_temperature
-  state_variable = true
   units = K
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -170,14 +166,12 @@
 [ pmiddry ]
   standard_name = air_pressure_of_dry_air
   long_name = Dry midpoint pressure
-  state_variable = true
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ temp ]
   standard_name = air_temperature
-  state_variable = true
   units = K
   type = real | kind = kind_phys
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -266,14 +260,12 @@
   intent = in
 [ pmid ]
   standard_name = air_pressure
-  state_variable = true
   type = real | kind = kind_phys
   units = Pa
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ exner ]
   standard_name = inverse_exner_function_wrt_surface_pressure
-  state_variable = true
   type = real | kind = kind_phys
   units = count
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -135,7 +135,7 @@
   standard_name = composition_dependent_gas_constant_of_dry_air
   long_name = dry air gas constant
   units = J kg-1 K-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ pmiddry ]
@@ -197,14 +197,14 @@
 [ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ rair ]
   standard_name = composition_dependent_gas_constant_of_dry_air
   long_name = ideal gas constant for dry air
   units = J kg-1 K-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ ref_pres ]

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -272,6 +272,7 @@
   intent = in
 [ qv ]
   standard_name = water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+  advected = True
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -463,6 +464,7 @@
   intent = in
 [ qv ]
   standard_name = water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
+  advected = True
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -524,6 +526,7 @@
 [ qc ]
   standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = Mass mixing ratio of cloud liquid water / moist air
+  advected = True
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -585,6 +588,7 @@
 [ qr ]
   standard_name = rain_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = Mass mixing ratio of rain / moist_air
+  advected = True
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -271,7 +271,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qv ]
-  standard_name = water_vapor_mixing_ratio_wrt_moist_air
+  standard_name = water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
@@ -462,7 +462,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qv ]
-  standard_name = water_vapor_mixing_ratio_wrt_moist_air
+  standard_name = water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water
   type = real | kind = kind_phys
   units = kg kg-1
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)

--- a/utilities/state_converters.meta
+++ b/utilities/state_converters.meta
@@ -331,8 +331,8 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qc ]
-  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air
-  long_name = Mass mixing ratio of cloud liquid water / moist_air
+  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = Mass mixing ratio of cloud liquid water / moist_air + condensed water
   advected = True
   type = real | kind = kind_phys
   units = kg kg-1
@@ -393,8 +393,8 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain__mixing_ratio_wrt_moist_air
-  long_name = Mass mixing ratio of rain / moist air
+  standard_name = rain_mixing_ratio_wrt_moist_air_and_condensed_water
+  long_name = Mass mixing ratio of rain / moist air + condensed water
   advected = True
   type = real | kind = kind_phys
   units = kg kg-1
@@ -522,7 +522,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qc ]
-  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air
+  standard_name = cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = Mass mixing ratio of cloud liquid water / moist air
   type = real | kind = kind_phys
   units = kg kg-1
@@ -583,7 +583,7 @@
   dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ qr ]
-  standard_name = rain_mixing_ratio_wrt_moist_air
+  standard_name = rain_mixing_ratio_wrt_moist_air_and_condensed_water
   long_name = Mass mixing ratio of rain / moist_air
   type = real | kind = kind_phys
   units = kg kg-1

--- a/utilities/static_energy.F90
+++ b/utilities/static_energy.F90
@@ -51,4 +51,4 @@ CONTAINS
 
    end subroutine update_dry_static_energy_run
 
-end module physics_tendency_updaters
+end module static_energy

--- a/utilities/static_energy.F90
+++ b/utilities/static_energy.F90
@@ -34,7 +34,7 @@ CONTAINS
       real(kind_phys),    intent(in)  :: zm(:,:)        ! geopotential height
       real(kind_phys),    intent(in)  :: phis(:)        ! surface geopotential
       real(kind_phys),    intent(out) :: st_energy(:,:) ! dry static energy
-      real(kind_phys),    intent(in)  :: cpair          ! specific heat, dry air
+      real(kind_phys),    intent(in)  :: cpair(:,:)     ! specific heat, dry air
       integer,            intent(out) :: errcode
       character(len=512), intent(out) :: errmsg
 
@@ -45,7 +45,7 @@ CONTAINS
       errmsg = ''
 
       do klev = 1, nz
-         st_energy(:, klev) = (temp(:, klev) * cpair) +                       &
+         st_energy(:, klev) = (temp(:, klev) * cpair(:,klev)) +               &
               (gravit * zm(:, klev)) + phis(:)
       end do
 

--- a/utilities/static_energy.F90
+++ b/utilities/static_energy.F90
@@ -5,31 +5,18 @@ module static_energy
   implicit none
   private
 
-  public :: update_dry_static_energy_init
   public :: update_dry_static_energy_run
-
-  ! Private module variables
-
-  real(kind_phys) :: gravit = -HUGE(1.0_kind_phys)
 
 CONTAINS
 
-   !> \section arg_table_update_dry_static_energy_init  Argument Table
-   !! \htmlinclude update_dry_static_energy_init.html
-   subroutine update_dry_static_energy_init(gravit_in)
-      real(kind_phys),    intent(in)    :: gravit_in
-
-      gravit = gravit_in
-
-   end subroutine update_dry_static_energy_init
-
    !> \section arg_table_update_dry_static_energy_run  Argument Table
    !! \htmlinclude update_dry_static_energy_run.html
-   subroutine update_dry_static_energy_run(nz, temp, zm, phis, st_energy,     &
-        cpair, errcode, errmsg)
+   subroutine update_dry_static_energy_run(nz, gravit, temp, zm, phis,        &
+        st_energy, cpair, errcode, errmsg)
 
       ! Dummy arguments
-      integer,            intent(in)  :: nz             ! Num vertical  layers
+      integer,            intent(in)  :: nz             ! Num vertical layers
+      real(kind_phys),    intent(in)  :: gravit         ! gravitational acceleration
       real(kind_phys),    intent(in)  :: temp(:,:)      ! air temperature
       real(kind_phys),    intent(in)  :: zm(:,:)        ! geopotential height
       real(kind_phys),    intent(in)  :: phis(:)        ! surface geopotential

--- a/utilities/static_energy.meta
+++ b/utilities/static_energy.meta
@@ -30,13 +30,13 @@
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ zm ]
-  standard_name = geopotential_height
+  standard_name = geopotential_height_wrt_surface
   type = real | kind = kind_phys
   units = m
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
 [ phis ]
-  standard_name = geopotential_at_surface
+  standard_name = surface_geopotential
   type = real | kind = kind_phys
   units = m2 s-2
   dimensions = (horizontal_dimension)
@@ -49,7 +49,7 @@
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
 [ cpair ]
-  standard_name = specific_heat_of_dry_air_at_constant_pressure
+  standard_name = composition_dependent_gas_constant_of_dry_air
   units = J kg-1 K-1
   dimensions = ()
   type = real | kind = kind_phys

--- a/utilities/static_energy.meta
+++ b/utilities/static_energy.meta
@@ -29,7 +29,6 @@
   units = K
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = in
-  state_variable = true
 [ zm ]
   standard_name = geopotential_height
   type = real | kind = kind_phys
@@ -45,7 +44,6 @@
 [ st_energy ]
   standard_name = dry_static_energy
   long_name = Dry static energy
-  state_variable = true
   type = real | kind = kind_phys
   units = J kg-1
   dimensions = (horizontal_dimension, vertical_layer_dimension)

--- a/utilities/static_energy.meta
+++ b/utilities/static_energy.meta
@@ -49,7 +49,7 @@
   dimensions = (horizontal_dimension, vertical_layer_dimension)
   intent = out
 [ cpair ]
-  standard_name = composition_dependent_gas_constant_of_dry_air
+  standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
   dimensions = ()
   type = real | kind = kind_phys

--- a/utilities/static_energy.meta
+++ b/utilities/static_energy.meta
@@ -2,17 +2,6 @@
 [ccpp-table-properties]
   name = update_dry_static_energy
   type = scheme
-
-[ccpp-arg-table]
-  name = update_dry_static_energy_init
-  type = scheme
-[ gravit_in ]
-  standard_name = gravitational_acceleration
-  units = m s-2
-  dimensions = ()
-  type = real | kind = kind_phys
-  intent = in
-
 [ccpp-arg-table]
   name = update_dry_static_energy_run
   type = scheme
@@ -22,6 +11,12 @@
   units = count
   dimensions = ()
   type = integer
+  intent = in
+[ gravit ]
+  standard_name = standard_gravitational_acceleration
+  units = m s-2
+  dimensions = ()
+  type = real | kind = kind_phys
   intent = in
 [ temp ]
   standard_name = air_temperature

--- a/utilities/static_energy.meta
+++ b/utilities/static_energy.meta
@@ -27,31 +27,31 @@
   standard_name = air_temperature
   type = real | kind = kind_phys
   units = K
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ zm ]
   standard_name = geopotential_height_wrt_surface
   type = real | kind = kind_phys
   units = m
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = in
 [ phis ]
   standard_name = surface_geopotential
   type = real | kind = kind_phys
   units = m2 s-2
-  dimensions = (horizontal_dimension)
+  dimensions = (horizontal_loop_extent)
   intent = in
 [ st_energy ]
   standard_name = dry_static_energy
   long_name = Dry static energy
   type = real | kind = kind_phys
   units = J kg-1
-  dimensions = (horizontal_dimension, vertical_layer_dimension)
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   intent = out
 [ cpair ]
   standard_name = composition_dependent_specific_heat_of_dry_air_at_constant_pressure
   units = J kg-1 K-1
-  dimensions = ()
+  dimensions = (horizontal_loop_extent, vertical_layer_dimension)
   type = real | kind = kind_phys
   intent = in
 [ errcode ]


### PR DESCRIPTION
The main purpose of this PR is to update the CCPP standard names to match the internal AMP agreed-upon names, as well as rename some of the physics routines to make them less ambigious and more accurate.  Along with these changes, significant code cleanup was performed along with some minor bug fixes, with the goal being to produce bit-for-bit results using the same repo version in both CAM and CAM-SIMA.

Fixes #60 
Fixes #61 
Fixes #62 
Fixes #64 
